### PR TITLE
Tighten deck deduplication and shrink deck list tiles

### DIFF
--- a/decks/apologies-for-lateness-u5-10.json
+++ b/decks/apologies-for-lateness-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "apologies-for-lateness-u5-10",
   "title": "Apologies: For Lateness (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the For Lateness subcategory within Apologies. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the For Lateness subcategory within Apologies. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "I'm sorry I'm late.",
-      "romaji": "Osoku natte gomen nasai.",
-      "japanese": "遅くなってごめんなさい。"
-    },
     {
       "english": "I'm sorry I'm late.",
       "romaji": "Osoku natte gomen nasai.",

--- a/decks/asking-for-directions-transportation-u5-10.json
+++ b/decks/asking-for-directions-transportation-u5-10.json
@@ -1,28 +1,8 @@
 {
   "id": "asking-for-directions-transportation-u5-10",
   "title": "Asking for Directions: Transportation (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Transportation subcategory within Asking for Directions. Includes 5 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Transportation subcategory within Asking for Directions. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "Where is the taxi stand?",
-      "romaji": "Takushinoriba wa doko ni arimasu ka.",
-      "japanese": "タクシー乗り場はどこにありますか。"
-    },
-    {
-      "english": "Where is the taxi stand?",
-      "romaji": "Takushinoriba wa doko ni arimasu ka.",
-      "japanese": "タクシー乗り場はどこにありますか。"
-    },
-    {
-      "english": "Where is the taxi stand?",
-      "romaji": "Takushinoriba wa doko ni arimasu ka.",
-      "japanese": "タクシー乗り場はどこにありますか。"
-    },
-    {
-      "english": "Where is the taxi stand?",
-      "romaji": "Takushinoriba wa doko ni arimasu ka.",
-      "japanese": "タクシー乗り場はどこにありますか。"
-    },
     {
       "english": "Where is the taxi stand?",
       "romaji": "Takushinoriba wa doko ni arimasu ka.",

--- a/decks/at-a-restaurant-ordering-u5-10.json
+++ b/decks/at-a-restaurant-ordering-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "at-a-restaurant-ordering-u5-10",
   "title": "At a Restaurant: Ordering (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Ordering subcategory within At a Restaurant. Includes 17 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Ordering subcategory within At a Restaurant. Includes 15 card(s).",
   "cards": [
     {
       "english": "Please give me this.",
@@ -17,11 +17,6 @@
       "english": "What do you recommend?",
       "romaji": "Nani ga o-susume desu ka.",
       "japanese": "何がおすすめですか。"
-    },
-    {
-      "english": "What do you recommend?",
-      "romaji": "O-susume wa nan desu ka.",
-      "japanese": "おすすめは何ですか？"
     },
     {
       "english": "Tempura, please.",
@@ -72,11 +67,6 @@
       "english": "Your order is?",
       "romaji": "Go-chumon wa?",
       "japanese": "ご注文は？"
-    },
-    {
-      "english": "Would you like rice or bread?",
-      "romaji": "Raisu to pan, dochira ga ii desu ka.",
-      "japanese": "ライスとパン、どちらがいいですか。"
     },
     {
       "english": "Start with your drink order, please.",

--- a/decks/at-the-hotel-amenities-u5-10.json
+++ b/decks/at-the-hotel-amenities-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "at-the-hotel-amenities-u5-10",
   "title": "At the Hotel: Amenities (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Amenities subcategory within At the Hotel. Includes 7 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Amenities subcategory within At the Hotel. Includes 5 card(s).",
   "cards": [
     {
       "english": "Do you have a power converter?",
@@ -17,16 +17,6 @@
       "english": "Do you have power converters?",
       "romaji": "Denryoku henkanki wa arimasu ka?",
       "japanese": "電力変換器はありますか？"
-    },
-    {
-      "english": "Do you have a hair dryer?",
-      "romaji": "Doraiya wa arimasu ka?",
-      "japanese": "ドライヤーはありますか？"
-    },
-    {
-      "english": "Do you have an iron?",
-      "romaji": "Airon wa arimasu ka.",
-      "japanese": "アイロンはありますか？"
     },
     {
       "english": "Do you have an iron?",

--- a/decks/clothing-traditional-u5-10.json
+++ b/decks/clothing-traditional-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "clothing-traditional-u5-10",
   "title": "Clothing: Traditional (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Traditional subcategory within Clothing. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Traditional subcategory within Clothing. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "I like kimonos.",
-      "romaji": "Watashi wa kimono ga suki desu.",
-      "japanese": "私は着物が好きです。"
-    },
     {
       "english": "I like kimonos.",
       "romaji": "Watashi wa kimono ga suki desu.",

--- a/decks/common-phrases-feelings-u1-5.json
+++ b/decks/common-phrases-feelings-u1-5.json
@@ -1,13 +1,8 @@
 {
   "id": "common-phrases-feelings-u1-5",
   "title": "Common Phrases: Feelings (Usefulness 1-5)",
-  "description": "Traveler usefulness 1-5/10 phrases for the Feelings subcategory within Common Phrases. Includes 2 card(s).",
+  "description": "Traveler usefulness 1-5/10 phrases for the Feelings subcategory within Common Phrases. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "I don't know what to do.",
-      "romaji": "Nani o sureba ii no ka wakaranai.",
-      "japanese": "何をすればいいのか分からない。"
-    },
     {
       "english": "I don't know what to do.",
       "romaji": "Nani o sureba ii no ka wakaranai.",

--- a/decks/common-responses-agreement-u5-10.json
+++ b/decks/common-responses-agreement-u5-10.json
@@ -1,17 +1,12 @@
 {
   "id": "common-responses-agreement-u5-10",
   "title": "Common Responses: Agreement (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Agreement subcategory within Common Responses. Includes 4 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Agreement subcategory within Common Responses. Includes 3 card(s).",
   "cards": [
     {
       "english": "That's right.",
       "romaji": "So desu.",
       "japanese": "そうです。"
-    },
-    {
-      "english": "Okay. / Good.",
-      "romaji": "Ii desu.",
-      "japanese": "いいです。"
     },
     {
       "english": "Okay. / Good.",

--- a/decks/common-responses-disagreement-correction-u5-10.json
+++ b/decks/common-responses-disagreement-correction-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "common-responses-disagreement-correction-u5-10",
   "title": "Common Responses: Disagreement / Correction (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Disagreement / Correction subcategory within Common Responses. Includes 7 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Disagreement / Correction subcategory within Common Responses. Includes 5 card(s).",
   "cards": [
     {
       "english": "That's incorrect.",
@@ -17,16 +17,6 @@
       "english": "That's not right.",
       "romaji": "Sore wa chigaimasu.",
       "japanese": "それは違います。"
-    },
-    {
-      "english": "No, that's wrong.",
-      "romaji": "Iie, chigaimasu.",
-      "japanese": "いいえ、違います。"
-    },
-    {
-      "english": "No, that's wrong.",
-      "romaji": "Iie, chigaimasu.",
-      "japanese": "いいえ、違います。"
     },
     {
       "english": "No, that's wrong.",

--- a/decks/common-responses-reassurance-u5-10.json
+++ b/decks/common-responses-reassurance-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "common-responses-reassurance-u5-10",
   "title": "Common Responses: Reassurance (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Reassurance subcategory within Common Responses. Includes 5 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Reassurance subcategory within Common Responses. Includes 4 card(s).",
   "cards": [
     {
       "english": "That's fine.",
@@ -15,11 +15,6 @@
     },
     {
       "english": "No, no, that's fine.",
-      "romaji": "Iie, iie.",
-      "japanese": "いいえ、いいえ。"
-    },
-    {
-      "english": "Don't worry about it.",
       "romaji": "Iie, iie.",
       "japanese": "いいえ、いいえ。"
     },

--- a/decks/communication-help-language-ability-u5-10.json
+++ b/decks/communication-help-language-ability-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "communication-help-language-ability-u5-10",
   "title": "Communication Help: Language Ability (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Language Ability subcategory within Communication Help. Includes 5 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Language Ability subcategory within Communication Help. Includes 4 card(s).",
   "cards": [
-    {
-      "english": "Can you speak English?",
-      "romaji": "Eigo o hanasemasu ka?",
-      "japanese": "英語を話せますか？"
-    },
     {
       "english": "Can you speak English?",
       "romaji": "Eigo o hanasemasu ka?",

--- a/decks/communication-help-repetition-u5-10.json
+++ b/decks/communication-help-repetition-u5-10.json
@@ -1,17 +1,12 @@
 {
   "id": "communication-help-repetition-u5-10",
   "title": "Communication Help: Repetition (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Repetition subcategory within Communication Help. Includes 6 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Repetition subcategory within Communication Help. Includes 5 card(s).",
   "cards": [
     {
       "english": "Can you say it again?",
       "romaji": "Mo ichido itte kudasai?",
       "japanese": "もう一度言ってください？"
-    },
-    {
-      "english": "Can you say it again?",
-      "romaji": "Mo ichido itte kudasai.",
-      "japanese": "もう一度言ってください。"
     },
     {
       "english": "What? Could you say that again?",

--- a/decks/counting-people-u5-10.json
+++ b/decks/counting-people-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "counting-people-u5-10",
   "title": "Counting: People (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the People subcategory within Counting. Includes 15 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the People subcategory within Counting. Includes 14 card(s).",
   "cards": [
     {
       "english": "How many people are in your party?",
@@ -27,11 +27,6 @@
       "english": "One person.",
       "romaji": "Ichi mei.",
       "japanese": "一名。"
-    },
-    {
-      "english": "Two people.",
-      "romaji": "Ni mei.",
-      "japanese": "二名。"
     },
     {
       "english": "Three people.",

--- a/decks/culture-food-u1-5.json
+++ b/decks/culture-food-u1-5.json
@@ -1,7 +1,7 @@
 {
   "id": "culture-food-u1-5",
   "title": "Culture: Food (Usefulness 1-5)",
-  "description": "Traveler usefulness 1-5/10 phrases for the Food subcategory within Culture. Includes 38 card(s).",
+  "description": "Traveler usefulness 1-5/10 phrases for the Food subcategory within Culture. Includes 33 card(s).",
   "cards": [
     {
       "english": "Traditionally people in West Japan enjoy tempura with salt, whereas people in East Japan dip it in a special sauce.",
@@ -79,19 +79,9 @@
       "japanese": "手作りの味噌汁は、家庭によって味が違います。"
     },
     {
-      "english": "Tempura is a Japanese dish.",
-      "romaji": "Tenpura wa nihon no ry.ri desu.",
-      "japanese": "天ぷらは日本の料理です。"
-    },
-    {
       "english": "Curry and rice is usually served on one plate, and consists of curry, white rice and special pickles called \"fukushinzuke\".",
       "romaji": "Kar. raisu wa, hitotsu no o-sara ni gohan, kar., fukujinzuke o moritukemasu.",
       "japanese": "カレーライスは、一つのお皿にご飯、カレー、福神漬けを盛り付けます。"
-    },
-    {
-      "english": "Traditionally people in West Japan enjoy tempura with salt, whereas people in East Japan dip it in a special sauce.",
-      "romaji": "Nishi Nihon de wa tempura o shio de tabemasu ga, higashi Nihon de wa tentsuyu ni tsukete tabemasu.",
-      "japanese": "西日本では天ぷらを塩で食べますが、東日本では天つゆにつけて食べます。"
     },
     {
       "english": "In winter, Japanese people enjoy hotpot dishes by sharing food in one big pot with family members.",
@@ -169,24 +159,9 @@
       "japanese": "梅干しは、通常ライスと一緒に食べられ、おにぎりの中身としても代表的な材料です。"
     },
     {
-      "english": "Cut mochi is enjoyed either grilled or cooked.",
-      "romaji": "Kirimochi wa yaitari ry.ri shitari shite tabemasu.",
-      "japanese": "切り餅は焼いたり料理したりして食べます。"
-    },
-    {
       "english": "Since matcha powder melts easily, it's enjoyed in various ways, such as mixed into vanilla ice cream and in matcha pound cake.",
       "romaji": "matcha no kona wa tokeyasui node, banira aisu to mazetari, matcha paundo k.ki ni shiy. shitari, iroirona h.h. de tanoshimemasu.",
       "japanese": "抹茶の粉は溶けやすいので、バニラアイスと混ぜたり、抹茶パウンドケーキに使用したり、色々な方法で楽しめます。"
-    },
-    {
-      "english": "There are glutinous rice-pounding events held locally in Japan on New Year's Day.",
-      "romaji": "O-sh.gatsu ni wa, chiiki de mochitsuki taikai ga okonawaremasu.",
-      "japanese": "お正月には、地域で餅つき大会が行われます。"
-    },
-    {
-      "english": "Sweet bean jelly is very sweet, so it goes well with a bitter green tea called \"matcha.\"",
-      "romaji": "Y.kan wa, totemo amai no de nigai matcha to yoku aimasu.",
-      "japanese": "羊羹は、とても甘いので苦い抹茶とよく合います。"
     },
     {
       "english": "A typical Japanese snack is senbei and green tea.",

--- a/decks/default-presets.json
+++ b/decks/default-presets.json
@@ -1,0 +1,607 @@
+[
+  {
+    "name": "Politeness & Gratitude",
+    "deckIds": [
+      "apologies-for-lateness-u5-10",
+      "apologies-formal-u5-10",
+      "apologies-general-u5-10",
+      "apologies-reassurance-u5-10",
+      "polite-expressions-apology-u5-10",
+      "polite-expressions-getting-attention-u5-10",
+      "polite-expressions-getting-attention-apology-u5-10",
+      "polite-expressions-offering-u5-10",
+      "polite-expressions-requests-u5-10",
+      "gratitude-expressing-thanks-u5-10",
+      "gratitude-expressing-thanks-casual-u5-10",
+      "gratitude-expressing-thanks-formal-u5-10",
+      "gratitude-responding-to-thanks-u5-10",
+      "gratitude-thanking-for-past-actions-u5-10",
+      "farewells-casual-u5-10",
+      "farewells-formal-u5-10",
+      "farewells-general-u5-10",
+      "common-phrases-desires-u5-10",
+      "common-phrases-identification-u5-10",
+      "common-phrases-ownership-u5-10",
+      "common-phrases-suggestions-u5-10"
+    ]
+  },
+  {
+    "name": "Greetings & Introductions",
+    "deckIds": [
+      "greetings-formal-u5-10",
+      "greetings-general-u5-10",
+      "greetings-responding-u5-10",
+      "greetings-time-of-day-u5-10",
+      "greetings-well-being-u5-10",
+      "introductions-confirmation-u5-10",
+      "introductions-formal-u5-10",
+      "introductions-initial-meeting-u5-10",
+      "introductions-name-u5-10",
+      "introductions-name-formal-u5-10",
+      "introductions-origin-u5-10",
+      "introductions-personal-information-u5-10",
+      "social-communication-u5-10",
+      "social-contact-info-u5-10",
+      "social-making-plans-u5-10",
+      "social-photos-u5-10",
+      "feelings-physical-state-u5-10",
+      "small-talk-weather-u5-10"
+    ]
+  },
+  {
+    "name": "Nightlife Connections",
+    "deckIds": [
+      "entertainment-bars-izakaya-u5-10",
+      "entertainment-karaoke-u5-10",
+      "entertainment-manga-cafe-u5-10",
+      "social-communication-u5-10",
+      "social-contact-info-u5-10",
+      "social-making-plans-u5-10",
+      "social-photos-u5-10",
+      "requests-casual-u5-10",
+      "requests-food-and-drink-u5-10",
+      "requests-formal-u5-10",
+      "requests-general-u5-10",
+      "requests-information-u5-10",
+      "requests-items-u5-10",
+      "requests-offering-u5-10",
+      "preferences-asking-u5-10",
+      "preferences-dislikes-u5-10",
+      "preferences-likes-u5-10"
+    ]
+  },
+  {
+    "name": "Communication Lifelines",
+    "deckIds": [
+      "communication-help-asking-for-assistance-u5-10",
+      "communication-help-getting-attention-u5-10",
+      "communication-help-lack-of-understanding-u5-10",
+      "communication-help-language-ability-u5-10",
+      "communication-help-pace-u5-10",
+      "communication-help-repetition-u5-10",
+      "language-help-ability-u5-10",
+      "language-help-comprehension-u5-10",
+      "language-help-meaning-u5-10",
+      "language-help-reading-u5-10",
+      "language-help-translation-u5-10",
+      "language-help-writing-u5-10",
+      "information-asking-for-assistance-u5-10",
+      "information-at-a-restaurant-u5-10"
+    ]
+  },
+  {
+    "name": "Questions & Responses",
+    "deckIds": [
+      "questions-asking-for-permission-u5-10",
+      "questions-comprehension-u5-10",
+      "questions-food-and-drink-u5-10",
+      "questions-identification-u5-10",
+      "questions-identity-u5-10",
+      "questions-language-u5-10",
+      "questions-location-u5-10",
+      "questions-opinion-u5-10",
+      "questions-ownership-u5-10",
+      "questions-personal-information-u5-10",
+      "questions-preferences-u5-10",
+      "questions-services-u5-10",
+      "questions-time-events-u5-10",
+      "common-responses-agreement-u5-10",
+      "common-responses-basic-answers-u5-10",
+      "common-responses-comprehension-u5-10",
+      "common-responses-disagreement-correction-u5-10",
+      "common-responses-negation-inability-u5-10",
+      "common-responses-reassurance-u5-10",
+      "common-responses-well-being-u5-10"
+    ]
+  },
+  {
+    "name": "Requests & Preferences",
+    "deckIds": [
+      "requests-casual-u5-10",
+      "requests-food-and-drink-u5-10",
+      "requests-formal-u5-10",
+      "requests-general-u5-10",
+      "requests-information-u5-10",
+      "requests-items-u5-10",
+      "requests-offering-u5-10",
+      "preferences-asking-u5-10",
+      "preferences-dislikes-u5-10",
+      "preferences-likes-u5-10",
+      "polite-expressions-apology-u5-10",
+      "polite-expressions-getting-attention-u5-10",
+      "polite-expressions-getting-attention-apology-u5-10",
+      "polite-expressions-offering-u5-10",
+      "polite-expressions-requests-u5-10"
+    ]
+  },
+  {
+    "name": "Navigation Basics",
+    "deckIds": [
+      "directions-instructions-u5-10",
+      "directions-locations-u5-10",
+      "directions-transportation-u5-10",
+      "directions-using-landmarks-u5-10",
+      "asking-for-directions-locations-u5-10",
+      "asking-for-directions-transportation-u5-10",
+      "travel-distance-u5-10",
+      "travel-documents-u5-10",
+      "travel-routes-u5-10",
+      "location-asking-u5-10",
+      "location-prepositions-u5-10"
+    ]
+  },
+  {
+    "name": "Transit Logistics",
+    "deckIds": [
+      "transportation-air-travel-u5-10",
+      "transportation-airport-u5-10",
+      "transportation-bus-u5-10",
+      "transportation-buying-tickets-u5-10",
+      "transportation-fares-u5-10",
+      "transportation-general-u5-10",
+      "transportation-taxi-u5-10",
+      "transportation-tickets-u5-10",
+      "transportation-train-u5-10",
+      "business-hours-closing-u5-10",
+      "business-hours-opening-u5-10"
+    ]
+  },
+  {
+    "name": "Counting & Comparisons",
+    "deckIds": [
+      "counting-food-and-drink-u5-10",
+      "counting-objects-u5-10",
+      "counting-people-u5-10",
+      "comparisons-size-u5-10",
+      "comparisons-speed-u5-10"
+    ]
+  },
+  {
+    "name": "Time & Schedules",
+    "deckIds": [
+      "telling-time-asking-the-time-u5-10",
+      "telling-time-duration-u5-10",
+      "telling-time-hours-u5-10",
+      "telling-time-relative-time-u5-10",
+      "telling-time-schedules-u5-10",
+      "telling-time-stating-the-time-u5-10",
+      "telling-time-vocabulary-u5-10",
+      "making-plans-scheduling-u5-10"
+    ]
+  },
+  {
+    "name": "Hotel & Concierge",
+    "deckIds": [
+      "at-the-hotel-amenities-u5-10",
+      "at-the-hotel-food-u5-10",
+      "at-the-hotel-room-features-u5-10",
+      "at-the-hotel-services-u5-10",
+      "renting-cell-phone-u5-10",
+      "information-asking-for-assistance-u5-10",
+      "information-at-a-restaurant-u5-10",
+      "lost-and-found-claiming-an-item-u5-10",
+      "lost-and-found-description-u5-10",
+      "lost-and-found-finding-the-office-u5-10",
+      "lost-and-found-inquiries-u5-10",
+      "lost-and-found-location-u5-10",
+      "lost-and-found-reporting-a-loss-u5-10"
+    ]
+  },
+  {
+    "name": "Postal & Practicalities",
+    "deckIds": [
+      "postal-service-describing-contents-u5-10",
+      "postal-service-questions-u5-10",
+      "postal-service-sending-items-u5-10",
+      "money-exchange-asking-the-rate-u5-10",
+      "money-exchange-making-a-request-u5-10",
+      "money-costs-and-fares-u5-10",
+      "money-currency-u5-10",
+      "money-numbers-u5-10",
+      "money-stating-price-u5-10",
+      "money-transportation-cards-u5-10",
+      "business-hours-closing-u5-10",
+      "business-hours-opening-u5-10"
+    ]
+  },
+  {
+    "name": "Shopping Essentials",
+    "deckIds": [
+      "shopping-asking-price-u5-10",
+      "shopping-buying-items-u5-10",
+      "shopping-clothing-u5-10",
+      "shopping-convenience-store-u5-10",
+      "shopping-finding-items-u5-10",
+      "shopping-food-u5-10",
+      "shopping-free-items-u5-10",
+      "shopping-general-u5-10",
+      "shopping-and-money-asking-prices-u5-10",
+      "shopping-and-money-bargaining-u5-10",
+      "shopping-and-money-business-hours-u5-10",
+      "shopping-and-money-commenting-on-price-u5-10",
+      "shopping-and-money-currency-exchange-u5-10",
+      "shopping-and-money-paying-u5-10",
+      "shopping-and-money-prices-u5-10",
+      "shopping-and-money-stating-price-u5-10",
+      "clothing-traditional-u5-10"
+    ]
+  },
+  {
+    "name": "Market Interactions",
+    "deckIds": [
+      "shopping-and-restaurants-buying-tickets-u5-10",
+      "shopping-and-restaurants-farewell-to-customers-u5-10",
+      "shopping-and-restaurants-greeting-customers-u5-10",
+      "shopping-and-restaurants-making-a-selection-u5-10",
+      "shopping-and-restaurants-ordering-u5-10",
+      "shopping-and-restaurants-paying-the-bill-u5-10",
+      "shopping-and-restaurants-thanking-customers-u5-10",
+      "money-costs-and-fares-u5-10",
+      "money-currency-u5-10",
+      "money-numbers-u5-10",
+      "money-stating-price-u5-10",
+      "money-transportation-cards-u5-10",
+      "money-exchange-asking-the-rate-u5-10",
+      "money-exchange-making-a-request-u5-10"
+    ]
+  },
+  {
+    "name": "Dining Out",
+    "deckIds": [
+      "at-a-restaurant-after-the-meal-u5-10",
+      "at-a-restaurant-asking-for-permission-u5-10",
+      "at-a-restaurant-asking-for-recommendations-u5-10",
+      "at-a-restaurant-before-the-meal-u5-10",
+      "at-a-restaurant-getting-attention-u5-10",
+      "at-a-restaurant-greeting-and-seating-u5-10",
+      "at-a-restaurant-ordering-u5-10",
+      "at-a-restaurant-paying-the-bill-u5-10",
+      "at-a-restaurant-stating-preferences-u5-10",
+      "shopping-and-restaurants-buying-tickets-u5-10",
+      "shopping-and-restaurants-farewell-to-customers-u5-10",
+      "shopping-and-restaurants-greeting-customers-u5-10",
+      "shopping-and-restaurants-making-a-selection-u5-10",
+      "shopping-and-restaurants-ordering-u5-10",
+      "shopping-and-restaurants-paying-the-bill-u5-10",
+      "shopping-and-restaurants-thanking-customers-u5-10"
+    ]
+  },
+  {
+    "name": "Dietary Support",
+    "deckIds": [
+      "dietary-needs-allergies-u5-10",
+      "dietary-needs-asking-about-ingredients-u5-10",
+      "dietary-needs-requests-u5-10",
+      "dietary-needs-restrictions-u5-10",
+      "dietary-needs-vegetarianism-u5-10",
+      "dietary-needs-vocabulary-u5-10",
+      "health-allergies-illness-u5-10",
+      "health-allergies-symptoms-u5-10",
+      "health-allergies-vocabulary-u5-10"
+    ]
+  },
+  {
+    "name": "Food Adventures",
+    "deckIds": [
+      "food-asking-about-experience-u5-10",
+      "food-asking-how-to-eat-u5-10",
+      "food-condiments-u5-10",
+      "food-descriptions-u5-10",
+      "food-desires-u5-10",
+      "food-drinks-u5-10",
+      "food-identification-u5-10",
+      "food-instructions-u5-10",
+      "food-local-specialties-u5-10",
+      "food-preferences-u5-10"
+    ]
+  },
+  {
+    "name": "Health Essentials",
+    "deckIds": [
+      "health-ailments-u5-10",
+      "health-allergies-u5-10",
+      "health-general-u5-10",
+      "health-illness-u5-10",
+      "health-locations-u5-10",
+      "health-medical-assistance-u5-10",
+      "health-pain-ailments-u5-10",
+      "health-symptoms-u5-10",
+      "health-pharmacy-medicine-u5-10"
+    ]
+  },
+  {
+    "name": "Body Focus",
+    "deckIds": [
+      "health-body-parts-ailments-u5-10",
+      "health-body-parts-face-u5-10",
+      "health-body-parts-injury-u5-10",
+      "health-body-parts-location-u5-10",
+      "health-body-parts-pain-u5-10",
+      "health-body-parts-sensations-u5-10"
+    ]
+  },
+  {
+    "name": "Emergency Response",
+    "deckIds": [
+      "emergency-actions-u5-10",
+      "emergency-calling-for-help-u5-10",
+      "emergency-earthquake-u5-10",
+      "emergency-evacuation-u5-10",
+      "emergency-fire-u5-10",
+      "emergency-preparedness-u5-10",
+      "emergency-providing-information-u5-10",
+      "emergency-tsunami-u5-10",
+      "rules-prohibitions-u5-10",
+      "health-pharmacy-medicine-u5-10"
+    ]
+  },
+  {
+    "name": "Connected Traveler",
+    "deckIds": [
+      "internet-and-technology-access-u5-10",
+      "internet-and-technology-internet-cafe-u5-10",
+      "internet-and-technology-login-u5-10",
+      "internet-and-technology-vocabulary-u5-10",
+      "internet-and-technology-wifi-u5-10",
+      "communication-help-asking-for-assistance-u5-10",
+      "communication-help-getting-attention-u5-10",
+      "communication-help-lack-of-understanding-u5-10",
+      "communication-help-language-ability-u5-10",
+      "communication-help-pace-u5-10",
+      "communication-help-repetition-u5-10",
+      "travel-distance-u5-10",
+      "travel-documents-u5-10",
+      "travel-routes-u5-10"
+    ]
+  },
+  {
+    "name": "Service Errands",
+    "deckIds": [
+      "postal-service-describing-contents-u5-10",
+      "postal-service-questions-u5-10",
+      "postal-service-sending-items-u5-10",
+      "lost-and-found-claiming-an-item-u5-10",
+      "lost-and-found-description-u5-10",
+      "lost-and-found-finding-the-office-u5-10",
+      "lost-and-found-inquiries-u5-10",
+      "lost-and-found-location-u5-10",
+      "lost-and-found-reporting-a-loss-u5-10",
+      "information-asking-for-assistance-u5-10",
+      "information-at-a-restaurant-u5-10"
+    ]
+  },
+  {
+    "name": "Customer Care",
+    "deckIds": [
+      "shopping-and-restaurants-buying-tickets-u5-10",
+      "shopping-and-restaurants-farewell-to-customers-u5-10",
+      "shopping-and-restaurants-greeting-customers-u5-10",
+      "shopping-and-restaurants-making-a-selection-u5-10",
+      "shopping-and-restaurants-ordering-u5-10",
+      "shopping-and-restaurants-paying-the-bill-u5-10",
+      "shopping-and-restaurants-thanking-customers-u5-10",
+      "polite-expressions-apology-u5-10",
+      "polite-expressions-getting-attention-u5-10",
+      "polite-expressions-getting-attention-apology-u5-10",
+      "polite-expressions-offering-u5-10",
+      "polite-expressions-requests-u5-10",
+      "requests-casual-u5-10",
+      "requests-food-and-drink-u5-10",
+      "requests-formal-u5-10",
+      "requests-general-u5-10",
+      "requests-information-u5-10",
+      "requests-items-u5-10",
+      "requests-offering-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Food Staples",
+    "deckIds": [
+      "vocabulary-food-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Places & Routes",
+    "deckIds": [
+      "vocabulary-places-and-things-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Concepts & Expressions",
+    "deckIds": [
+      "vocabulary-concepts-u5-10",
+      "vocabulary-exclamations-u5-10",
+      "vocabulary-animals-u5-10",
+      "nature-plants-u5-10",
+      "weather-temperature-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Action Verbs",
+    "deckIds": [
+      "vocabulary-verbs-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Descriptive Language",
+    "deckIds": [
+      "descriptions-aesthetics-u5-10",
+      "descriptions-color-clothing-u5-10",
+      "descriptions-color-nature-u5-10",
+      "descriptions-places-u5-10",
+      "vocabulary-adjectives-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Everyday Items",
+    "deckIds": [
+      "vocabulary-other-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: People Skills",
+    "deckIds": [
+      "introductions-confirmation-u5-10",
+      "introductions-formal-u5-10",
+      "introductions-initial-meeting-u5-10",
+      "introductions-name-u5-10",
+      "introductions-name-formal-u5-10",
+      "introductions-origin-u5-10",
+      "introductions-personal-information-u5-10",
+      "social-communication-u5-10",
+      "social-contact-info-u5-10",
+      "social-making-plans-u5-10",
+      "social-photos-u5-10",
+      "vocabulary-people-u5-10"
+    ]
+  },
+  {
+    "name": "Vocabulary: Number Sense",
+    "deckIds": [
+      "counting-people-u5-10",
+      "counting-food-and-drink-u5-10",
+      "counting-objects-u5-10"
+    ]
+  },
+  {
+    "name": "Travel Paperwork",
+    "deckIds": [
+      "travel-distance-u5-10",
+      "travel-documents-u5-10",
+      "travel-routes-u5-10",
+      "postal-service-describing-contents-u5-10",
+      "postal-service-questions-u5-10",
+      "postal-service-sending-items-u5-10",
+      "money-exchange-asking-the-rate-u5-10",
+      "money-exchange-making-a-request-u5-10",
+      "business-hours-closing-u5-10",
+      "business-hours-opening-u5-10"
+    ]
+  },
+  {
+    "name": "Hospital Visit Prep",
+    "deckIds": [
+      "health-ailments-u5-10",
+      "health-allergies-u5-10",
+      "health-general-u5-10",
+      "health-illness-u5-10",
+      "health-locations-u5-10",
+      "health-medical-assistance-u5-10",
+      "health-pain-ailments-u5-10",
+      "health-symptoms-u5-10",
+      "health-pharmacy-medicine-u5-10",
+      "health-allergies-illness-u5-10",
+      "health-allergies-symptoms-u5-10",
+      "health-allergies-vocabulary-u5-10"
+    ]
+  },
+  {
+    "name": "Medical Emergencies",
+    "deckIds": [
+      "emergency-actions-u5-10",
+      "emergency-calling-for-help-u5-10",
+      "emergency-earthquake-u5-10",
+      "emergency-evacuation-u5-10",
+      "emergency-fire-u5-10",
+      "emergency-preparedness-u5-10",
+      "emergency-providing-information-u5-10",
+      "emergency-tsunami-u5-10",
+      "health-pharmacy-medicine-u5-10",
+      "communication-help-asking-for-assistance-u5-10",
+      "communication-help-getting-attention-u5-10",
+      "communication-help-lack-of-understanding-u5-10",
+      "communication-help-language-ability-u5-10",
+      "communication-help-pace-u5-10",
+      "communication-help-repetition-u5-10"
+    ]
+  },
+  {
+    "name": "Safety Briefings",
+    "deckIds": [
+      "emergency-actions-u5-10",
+      "emergency-calling-for-help-u5-10",
+      "emergency-earthquake-u5-10",
+      "emergency-evacuation-u5-10",
+      "emergency-fire-u5-10",
+      "emergency-preparedness-u5-10",
+      "emergency-providing-information-u5-10",
+      "emergency-tsunami-u5-10",
+      "communication-help-asking-for-assistance-u5-10",
+      "communication-help-getting-attention-u5-10",
+      "communication-help-lack-of-understanding-u5-10",
+      "communication-help-language-ability-u5-10",
+      "communication-help-pace-u5-10",
+      "communication-help-repetition-u5-10"
+    ]
+  },
+  {
+    "name": "Transit Tickets",
+    "deckIds": [
+      "transportation-air-travel-u5-10",
+      "transportation-airport-u5-10",
+      "transportation-bus-u5-10",
+      "transportation-buying-tickets-u5-10",
+      "transportation-fares-u5-10",
+      "transportation-general-u5-10",
+      "transportation-taxi-u5-10",
+      "transportation-tickets-u5-10",
+      "transportation-train-u5-10",
+      "money-exchange-asking-the-rate-u5-10",
+      "money-exchange-making-a-request-u5-10"
+    ]
+  },
+  {
+    "name": "Dining Requests",
+    "deckIds": [
+      "at-a-restaurant-ordering-u5-10",
+      "at-a-restaurant-stating-preferences-u5-10",
+      "dietary-needs-requests-u5-10",
+      "preferences-likes-u5-10",
+      "preferences-dislikes-u5-10"
+    ]
+  },
+  {
+    "name": "Guided Tours",
+    "deckIds": [
+      "directions-instructions-u5-10",
+      "directions-locations-u5-10",
+      "directions-transportation-u5-10",
+      "directions-using-landmarks-u5-10",
+      "information-asking-for-assistance-u5-10",
+      "information-at-a-restaurant-u5-10"
+    ]
+  },
+  {
+    "name": "Local Services",
+    "deckIds": [
+      "postal-service-describing-contents-u5-10",
+      "postal-service-questions-u5-10",
+      "postal-service-sending-items-u5-10",
+      "renting-cell-phone-u5-10",
+      "money-exchange-asking-the-rate-u5-10",
+      "money-exchange-making-a-request-u5-10",
+      "information-asking-for-assistance-u5-10",
+      "information-at-a-restaurant-u5-10"
+    ]
+  }
+]

--- a/decks/directions-instructions-u5-10.json
+++ b/decks/directions-instructions-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "directions-instructions-u5-10",
   "title": "Directions: Instructions (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Instructions subcategory within Directions. Includes 15 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Instructions subcategory within Directions. Includes 14 card(s).",
   "cards": [
     {
       "english": "Go straight.",
@@ -72,11 +72,6 @@
       "english": "Then turn left at the third traffic signal.",
       "romaji": "Sanban-me no shingo wo hidari ni magarimasu.",
       "japanese": "三番目の信号を左に曲がります。"
-    },
-    {
-      "english": "Turn right at the dead end.",
-      "romaji": "Tsuki atari de migi ni magaru.",
-      "japanese": "突き当たりで右に曲がる。"
     }
   ]
 }

--- a/decks/food-identification-u5-10.json
+++ b/decks/food-identification-u5-10.json
@@ -1,17 +1,12 @@
 {
   "id": "food-identification-u5-10",
   "title": "Food: Identification (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Food. Includes 3 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Food. Includes 2 card(s).",
   "cards": [
     {
       "english": "This is meat.",
       "romaji": "Kore wa niku desu.",
       "japanese": "これは肉です。"
-    },
-    {
-      "english": "Milk and cheese are dairy products.",
-      "romaji": "Gyunyu to chizu wa nyuseihin desu.",
-      "japanese": "牛乳とチーズは乳製品です。"
     },
     {
       "english": "Milk and cheese are dairy products.",

--- a/decks/gratitude-expressing-thanks-formal-u5-10.json
+++ b/decks/gratitude-expressing-thanks-formal-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "gratitude-expressing-thanks-formal-u5-10",
   "title": "Gratitude: Expressing Thanks (Formal) (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks (Formal) subcategory within Gratitude. Includes 3 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks (Formal) subcategory within Gratitude. Includes 2 card(s).",
   "cards": [
     {
       "english": "Thank you very much. (very formal)",
@@ -12,11 +12,6 @@
       "english": "Thank you very much!",
       "romaji": "Arigato gozaimasu.",
       "japanese": "ありがとうございます！"
-    },
-    {
-      "english": "Thank you very much.",
-      "romaji": "Domo arigato gozaimasu.",
-      "japanese": "どうもありがとうございます。"
     }
   ]
 }

--- a/decks/gratitude-expressing-thanks-u5-10.json
+++ b/decks/gratitude-expressing-thanks-u5-10.json
@@ -1,17 +1,12 @@
 {
   "id": "gratitude-expressing-thanks-u5-10",
   "title": "Gratitude: Expressing Thanks (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks subcategory within Gratitude. Includes 3 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks subcategory within Gratitude. Includes 2 card(s).",
   "cards": [
     {
       "english": "Thank you.",
       "romaji": "Arigato.",
       "japanese": "ありがとう。"
-    },
-    {
-      "english": "Thank you very much.",
-      "romaji": "Domo arigato gozaimasu.",
-      "japanese": "どうもありがとうございます。"
     },
     {
       "english": "Thank you very much.",

--- a/decks/health-allergies-u5-10.json
+++ b/decks/health-allergies-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "health-allergies-u5-10",
   "title": "Health: Allergies (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Allergies subcategory within Health. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Allergies subcategory within Health. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "I have allergies.",
-      "romaji": "Arerugi ga arimasu.",
-      "japanese": "アレルギーがあります。"
-    },
     {
       "english": "I have allergies.",
       "romaji": "Arerugi ga arimasu.",

--- a/decks/health-body-parts-pain-u5-10.json
+++ b/decks/health-body-parts-pain-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "health-body-parts-pain-u5-10",
   "title": "Health (Body Parts): Pain (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Pain subcategory within Health (Body Parts). Includes 32 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Pain subcategory within Health (Body Parts). Includes 28 card(s).",
   "cards": [
     {
       "english": "My abdomen hurts.",
@@ -79,11 +79,6 @@
       "japanese": "肩が痛いです。"
     },
     {
-      "english": "My neck hurts.",
-      "romaji": "Kubi ga itai desu.",
-      "japanese": "首が痛いです。"
-    },
-    {
       "english": "My arms hurt.",
       "romaji": "Ude ga itai desu.",
       "japanese": "腕が痛いです。"
@@ -114,16 +109,6 @@
       "japanese": "胸が痛いです。"
     },
     {
-      "english": "My back hurts.",
-      "romaji": "Senaka ga itai desu.",
-      "japanese": "背中が痛いです。"
-    },
-    {
-      "english": "My lower back hurts.",
-      "romaji": "Koshi ga itai desu.",
-      "japanese": "腰が痛いです。"
-    },
-    {
       "english": "My buttocks hurt.",
       "romaji": "Shiri ga itai desu.",
       "japanese": "尻が痛いです。"
@@ -142,11 +127,6 @@
       "english": "My ankles hurt.",
       "romaji": "Ashikubi ga itai desu.",
       "japanese": "足首が痛いです。"
-    },
-    {
-      "english": "My thighs hurt.",
-      "romaji": "Futomomo ga itai desu.",
-      "japanese": "太ももが痛いです。"
     },
     {
       "english": "My calves hurt.",

--- a/decks/health-general-u5-10.json
+++ b/decks/health-general-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "health-general-u5-10",
   "title": "Health: General (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the General subcategory within Health. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the General subcategory within Health. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "I often get sick.",
-      "romaji": "Yoku byoki wo suru.",
-      "japanese": "よく病気をする。"
-    },
     {
       "english": "I often get sick.",
       "romaji": "Yoku byoki wo suru.",

--- a/decks/health-illness-u5-10.json
+++ b/decks/health-illness-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "health-illness-u5-10",
   "title": "Health: Illness (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Illness subcategory within Health. Includes 5 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Illness subcategory within Health. Includes 4 card(s).",
   "cards": [
     {
       "english": "I have a cold.",
@@ -22,11 +22,6 @@
       "english": "I caught a cold.",
       "romaji": "Kaze wo hita.",
       "japanese": "風邪をひいた。"
-    },
-    {
-      "english": "I got an upset stomach.",
-      "romaji": "O-naka o kowashita.",
-      "japanese": "お腹を壊した。"
     }
   ]
 }

--- a/decks/health-pain-ailments-u5-10.json
+++ b/decks/health-pain-ailments-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "health-pain-ailments-u5-10",
   "title": "Health: Pain / Ailments (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Pain / Ailments subcategory within Health. Includes 7 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Pain / Ailments subcategory within Health. Includes 6 card(s).",
   "cards": [
     {
       "english": "My stomach hurts.",
@@ -17,11 +17,6 @@
       "english": "I have a headache.",
       "romaji": "Atama ga itai desu.",
       "japanese": "頭が痛いです。"
-    },
-    {
-      "english": "I have a headache.",
-      "romaji": "Zutsu ga shimasu.",
-      "japanese": "頭痛がします。"
     },
     {
       "english": "I have a sore throat.",

--- a/decks/health-symptoms-u5-10.json
+++ b/decks/health-symptoms-u5-10.json
@@ -1,17 +1,12 @@
 {
   "id": "health-symptoms-u5-10",
   "title": "Health: Symptoms (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Symptoms subcategory within Health. Includes 5 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Symptoms subcategory within Health. Includes 4 card(s).",
   "cards": [
     {
       "english": "Do you have diarrhea?",
       "romaji": "Geri shite imasu ka?",
       "japanese": "下痢していますか？"
-    },
-    {
-      "english": "Do you have diarrhea?",
-      "romaji": "Geri shite imasu ka.",
-      "japanese": "下痢していますか。"
     },
     {
       "english": "I have a fever.",

--- a/decks/holidays-and-events-o-bon-u1-5.json
+++ b/decks/holidays-and-events-o-bon-u1-5.json
@@ -1,13 +1,8 @@
 {
   "id": "holidays-and-events-o-bon-u1-5",
   "title": "Holidays & Events: O-bon (Usefulness 1-5)",
-  "description": "Traveler usefulness 1-5/10 phrases for the O-bon subcategory within Holidays & Events. Includes 2 card(s).",
+  "description": "Traveler usefulness 1-5/10 phrases for the O-bon subcategory within Holidays & Events. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "O-bon is a period of honoring one's ancestors, so it's important to clean the family graves before welcoming their spirits.",
-      "romaji": "O-bon wa sosen o matsuru kikan nanode, sosen no rei o mukaeru mae ni o-haka o soji suru no wa taisetsu na koto desu.",
-      "japanese": "お盆は祖先を祭る期間なので、祖先の霊を迎える前にお墓を掃除するのは大切なことです。"
-    },
     {
       "english": "O-bon is a period of honoring one's ancestors, so it's important to clean the family graves before welcoming their spirits.",
       "romaji": "O-bon wa sosen o matsuru kikan nanode, sosen no rei o mukaeru mae ni o-haka o soji suru no wa taisetsu na koto desu.",

--- a/decks/internet-and-technology-login-u5-10.json
+++ b/decks/internet-and-technology-login-u5-10.json
@@ -1,16 +1,11 @@
 {
   "id": "internet-and-technology-login-u5-10",
   "title": "Internet & Technology: Login (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Login subcategory within Internet & Technology. Includes 3 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Login subcategory within Internet & Technology. Includes 2 card(s).",
   "cards": [
     {
       "english": "Username and password please.",
       "romaji": "Yuzanemu to pasuwado o onegai shimasu.",
-      "japanese": "ユーザーネームとパスワードをお願いします。"
-    },
-    {
-      "english": "User name and password please.",
-      "romaji": "Yuza nemu to pasuwado wo onegai shimasu.",
       "japanese": "ユーザーネームとパスワードをお願いします。"
     },
     {

--- a/decks/introductions-initial-meeting-u5-10.json
+++ b/decks/introductions-initial-meeting-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "introductions-initial-meeting-u5-10",
   "title": "Introductions: Initial Meeting (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Initial Meeting subcategory within Introductions. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Initial Meeting subcategory within Introductions. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "Nice to meet you.",
-      "romaji": "Hajimemashite.",
-      "japanese": "はじめまして。"
-    },
     {
       "english": "Nice to meet you.",
       "romaji": "Hajimemashite.",

--- a/decks/introductions-origin-u5-10.json
+++ b/decks/introductions-origin-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "introductions-origin-u5-10",
   "title": "Introductions: Origin (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Origin subcategory within Introductions. Includes 8 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Origin subcategory within Introductions. Includes 7 card(s).",
   "cards": [
     {
       "english": "I'm from Tokyo.",
@@ -22,11 +22,6 @@
       "english": "I am from XXX.",
       "romaji": "XXX shusshin desu.",
       "japanese": "XXX出身です。"
-    },
-    {
-      "english": "I'm from Tokyo.",
-      "romaji": "Shusshin wa T ky desu.",
-      "japanese": "出身は東京です。"
     },
     {
       "english": "My hometown is Tokyo.",

--- a/decks/language-help-comprehension-u5-10.json
+++ b/decks/language-help-comprehension-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "language-help-comprehension-u5-10",
   "title": "Language Help: Comprehension (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Comprehension subcategory within Language Help. Includes 4 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Comprehension subcategory within Language Help. Includes 3 card(s).",
   "cards": [
     {
       "english": "Do you understand English?",
@@ -12,11 +12,6 @@
       "english": "I don't understand what you mean.",
       "romaji": "Imi ga wakarimasen.",
       "japanese": "意味が分かりません。"
-    },
-    {
-      "english": "Do you understand English?",
-      "romaji": "Eigo ga wakarimasu ka.",
-      "japanese": "英語が分かりますか。"
     },
     {
       "english": "I don't understand Japanese.",

--- a/decks/language-help-reading-u5-10.json
+++ b/decks/language-help-reading-u5-10.json
@@ -1,17 +1,12 @@
 {
   "id": "language-help-reading-u5-10",
   "title": "Language Help: Reading (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Reading subcategory within Language Help. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Reading subcategory within Language Help. Includes 1 card(s).",
   "cards": [
     {
       "english": "How do you read this?",
       "romaji": "Kore wa do yomimasu ka?",
       "japanese": "これはどう読みますか？"
-    },
-    {
-      "english": "How do you read this?",
-      "romaji": "Kore wa do yomimasu ka.",
-      "japanese": "これはどう読みますか。"
     }
   ]
 }

--- a/decks/language-help-writing-systems-u1-5.json
+++ b/decks/language-help-writing-systems-u1-5.json
@@ -1,18 +1,8 @@
 {
   "id": "language-help-writing-systems-u1-5",
   "title": "Language Help: Writing Systems (Usefulness 1-5)",
-  "description": "Traveler usefulness 1-5/10 phrases for the Writing Systems subcategory within Language Help. Includes 5 card(s).",
+  "description": "Traveler usefulness 1-5/10 phrases for the Writing Systems subcategory within Language Help. Includes 3 card(s).",
   "cards": [
-    {
-      "english": "Please teach me hiragana.",
-      "romaji": "Hiragana wo oshiete kudasai.",
-      "japanese": "ひらがなを教えてください。"
-    },
-    {
-      "english": "I don't know Katakana.",
-      "romaji": "Katakana wa wakarimasen.",
-      "japanese": "カタカナはわかりません。"
-    },
     {
       "english": "Please teach me hiragana.",
       "romaji": "Hiragana wo oshiete kudasai.",

--- a/decks/manifest.json
+++ b/decks/manifest.json
@@ -8,7 +8,7 @@
   {
     "id": "apologies-for-lateness-u5-10",
     "title": "Apologies: For Lateness (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the For Lateness subcategory within Apologies. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the For Lateness subcategory within Apologies. Includes 1 card(s).",
     "file": "apologies-for-lateness-u5-10.json"
   },
   {
@@ -38,7 +38,7 @@
   {
     "id": "asking-for-directions-transportation-u5-10",
     "title": "Asking for Directions: Transportation (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Transportation subcategory within Asking for Directions. Includes 5 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Transportation subcategory within Asking for Directions. Includes 1 card(s).",
     "file": "asking-for-directions-transportation-u5-10.json"
   },
   {
@@ -80,7 +80,7 @@
   {
     "id": "at-a-restaurant-ordering-u5-10",
     "title": "At a Restaurant: Ordering (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Ordering subcategory within At a Restaurant. Includes 17 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Ordering subcategory within At a Restaurant. Includes 15 card(s).",
     "file": "at-a-restaurant-ordering-u5-10.json"
   },
   {
@@ -104,7 +104,7 @@
   {
     "id": "at-the-hotel-amenities-u5-10",
     "title": "At the Hotel: Amenities (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Amenities subcategory within At the Hotel. Includes 7 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Amenities subcategory within At the Hotel. Includes 5 card(s).",
     "file": "at-the-hotel-amenities-u5-10.json"
   },
   {
@@ -170,7 +170,7 @@
   {
     "id": "clothing-traditional-u5-10",
     "title": "Clothing: Traditional (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Traditional subcategory within Clothing. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Traditional subcategory within Clothing. Includes 1 card(s).",
     "file": "clothing-traditional-u5-10.json"
   },
   {
@@ -206,7 +206,7 @@
   {
     "id": "common-phrases-feelings-u1-5",
     "title": "Common Phrases: Feelings (Usefulness 1-5)",
-    "description": "Traveler usefulness 1-5/10 phrases for the Feelings subcategory within Common Phrases. Includes 2 card(s).",
+    "description": "Traveler usefulness 1-5/10 phrases for the Feelings subcategory within Common Phrases. Includes 1 card(s).",
     "file": "common-phrases-feelings-u1-5.json"
   },
   {
@@ -296,7 +296,7 @@
   {
     "id": "common-responses-agreement-u5-10",
     "title": "Common Responses: Agreement (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Agreement subcategory within Common Responses. Includes 4 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Agreement subcategory within Common Responses. Includes 3 card(s).",
     "file": "common-responses-agreement-u5-10.json"
   },
   {
@@ -314,7 +314,7 @@
   {
     "id": "common-responses-disagreement-correction-u5-10",
     "title": "Common Responses: Disagreement / Correction (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Disagreement / Correction subcategory within Common Responses. Includes 7 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Disagreement / Correction subcategory within Common Responses. Includes 5 card(s).",
     "file": "common-responses-disagreement-correction-u5-10.json"
   },
   {
@@ -326,7 +326,7 @@
   {
     "id": "common-responses-reassurance-u5-10",
     "title": "Common Responses: Reassurance (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Reassurance subcategory within Common Responses. Includes 5 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Reassurance subcategory within Common Responses. Includes 4 card(s).",
     "file": "common-responses-reassurance-u5-10.json"
   },
   {
@@ -362,7 +362,7 @@
   {
     "id": "communication-help-language-ability-u5-10",
     "title": "Communication Help: Language Ability (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Language Ability subcategory within Communication Help. Includes 5 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Language Ability subcategory within Communication Help. Includes 4 card(s).",
     "file": "communication-help-language-ability-u5-10.json"
   },
   {
@@ -374,7 +374,7 @@
   {
     "id": "communication-help-repetition-u5-10",
     "title": "Communication Help: Repetition (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Repetition subcategory within Communication Help. Includes 6 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Repetition subcategory within Communication Help. Includes 5 card(s).",
     "file": "communication-help-repetition-u5-10.json"
   },
   {
@@ -410,7 +410,7 @@
   {
     "id": "counting-people-u5-10",
     "title": "Counting: People (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the People subcategory within Counting. Includes 15 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the People subcategory within Counting. Includes 14 card(s).",
     "file": "counting-people-u5-10.json"
   },
   {
@@ -452,7 +452,7 @@
   {
     "id": "culture-food-u1-5",
     "title": "Culture: Food (Usefulness 1-5)",
-    "description": "Traveler usefulness 1-5/10 phrases for the Food subcategory within Culture. Includes 38 card(s).",
+    "description": "Traveler usefulness 1-5/10 phrases for the Food subcategory within Culture. Includes 33 card(s).",
     "file": "culture-food-u1-5.json"
   },
   {
@@ -608,7 +608,7 @@
   {
     "id": "directions-instructions-u5-10",
     "title": "Directions: Instructions (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Instructions subcategory within Directions. Includes 15 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Instructions subcategory within Directions. Includes 14 card(s).",
     "file": "directions-instructions-u5-10.json"
   },
   {
@@ -890,7 +890,7 @@
   {
     "id": "food-identification-u5-10",
     "title": "Food: Identification (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Food. Includes 3 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Food. Includes 2 card(s).",
     "file": "food-identification-u5-10.json"
   },
   {
@@ -962,7 +962,7 @@
   {
     "id": "gratitude-expressing-thanks-u5-10",
     "title": "Gratitude: Expressing Thanks (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks subcategory within Gratitude. Includes 3 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks subcategory within Gratitude. Includes 2 card(s).",
     "file": "gratitude-expressing-thanks-u5-10.json"
   },
   {
@@ -974,7 +974,7 @@
   {
     "id": "gratitude-expressing-thanks-formal-u5-10",
     "title": "Gratitude: Expressing Thanks (Formal) (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks (Formal) subcategory within Gratitude. Includes 3 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Expressing Thanks (Formal) subcategory within Gratitude. Includes 2 card(s).",
     "file": "gratitude-expressing-thanks-formal-u5-10.json"
   },
   {
@@ -1052,19 +1052,19 @@
   {
     "id": "health-allergies-u5-10",
     "title": "Health: Allergies (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Allergies subcategory within Health. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Allergies subcategory within Health. Includes 1 card(s).",
     "file": "health-allergies-u5-10.json"
   },
   {
     "id": "health-general-u5-10",
     "title": "Health: General (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the General subcategory within Health. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the General subcategory within Health. Includes 1 card(s).",
     "file": "health-general-u5-10.json"
   },
   {
     "id": "health-illness-u5-10",
     "title": "Health: Illness (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Illness subcategory within Health. Includes 5 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Illness subcategory within Health. Includes 4 card(s).",
     "file": "health-illness-u5-10.json"
   },
   {
@@ -1088,13 +1088,13 @@
   {
     "id": "health-pain-ailments-u5-10",
     "title": "Health: Pain / Ailments (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Pain / Ailments subcategory within Health. Includes 7 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Pain / Ailments subcategory within Health. Includes 6 card(s).",
     "file": "health-pain-ailments-u5-10.json"
   },
   {
     "id": "health-symptoms-u5-10",
     "title": "Health: Symptoms (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Symptoms subcategory within Health. Includes 5 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Symptoms subcategory within Health. Includes 4 card(s).",
     "file": "health-symptoms-u5-10.json"
   },
   {
@@ -1154,7 +1154,7 @@
   {
     "id": "health-body-parts-pain-u5-10",
     "title": "Health (Body Parts): Pain (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Pain subcategory within Health (Body Parts). Includes 32 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Pain subcategory within Health (Body Parts). Includes 28 card(s).",
     "file": "health-body-parts-pain-u5-10.json"
   },
   {
@@ -1232,7 +1232,7 @@
   {
     "id": "holidays-and-events-o-bon-u1-5",
     "title": "Holidays & Events: O-bon (Usefulness 1-5)",
-    "description": "Traveler usefulness 1-5/10 phrases for the O-bon subcategory within Holidays & Events. Includes 2 card(s).",
+    "description": "Traveler usefulness 1-5/10 phrases for the O-bon subcategory within Holidays & Events. Includes 1 card(s).",
     "file": "holidays-and-events-o-bon-u1-5.json"
   },
   {
@@ -1316,7 +1316,7 @@
   {
     "id": "internet-and-technology-login-u5-10",
     "title": "Internet & Technology: Login (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Login subcategory within Internet & Technology. Includes 3 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Login subcategory within Internet & Technology. Includes 2 card(s).",
     "file": "internet-and-technology-login-u5-10.json"
   },
   {
@@ -1358,7 +1358,7 @@
   {
     "id": "introductions-initial-meeting-u5-10",
     "title": "Introductions: Initial Meeting (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Initial Meeting subcategory within Introductions. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Initial Meeting subcategory within Introductions. Includes 1 card(s).",
     "file": "introductions-initial-meeting-u5-10.json"
   },
   {
@@ -1382,7 +1382,7 @@
   {
     "id": "introductions-origin-u5-10",
     "title": "Introductions: Origin (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Origin subcategory within Introductions. Includes 8 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Origin subcategory within Introductions. Includes 7 card(s).",
     "file": "introductions-origin-u5-10.json"
   },
   {
@@ -1412,7 +1412,7 @@
   {
     "id": "language-help-comprehension-u5-10",
     "title": "Language Help: Comprehension (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Comprehension subcategory within Language Help. Includes 4 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Comprehension subcategory within Language Help. Includes 3 card(s).",
     "file": "language-help-comprehension-u5-10.json"
   },
   {
@@ -1424,7 +1424,7 @@
   {
     "id": "language-help-reading-u5-10",
     "title": "Language Help: Reading (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Reading subcategory within Language Help. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Reading subcategory within Language Help. Includes 1 card(s).",
     "file": "language-help-reading-u5-10.json"
   },
   {
@@ -1442,7 +1442,7 @@
   {
     "id": "language-help-writing-systems-u1-5",
     "title": "Language Help: Writing Systems (Usefulness 1-5)",
-    "description": "Traveler usefulness 1-5/10 phrases for the Writing Systems subcategory within Language Help. Includes 5 card(s).",
+    "description": "Traveler usefulness 1-5/10 phrases for the Writing Systems subcategory within Language Help. Includes 3 card(s).",
     "file": "language-help-writing-systems-u1-5.json"
   },
   {
@@ -1712,7 +1712,7 @@
   {
     "id": "questions-identification-u5-10",
     "title": "Questions: Identification (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Questions. Includes 4 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Questions. Includes 2 card(s).",
     "file": "questions-identification-u5-10.json"
   },
   {
@@ -1742,19 +1742,19 @@
   {
     "id": "questions-opinion-u5-10",
     "title": "Questions: Opinion (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Opinion subcategory within Questions. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Opinion subcategory within Questions. Includes 1 card(s).",
     "file": "questions-opinion-u5-10.json"
   },
   {
     "id": "questions-ownership-u1-5",
     "title": "Questions: Ownership (Usefulness 1-5)",
-    "description": "Traveler usefulness 1-5/10 phrases for the Ownership subcategory within Questions. Includes 5 card(s).",
+    "description": "Traveler usefulness 1-5/10 phrases for the Ownership subcategory within Questions. Includes 1 card(s).",
     "file": "questions-ownership-u1-5.json"
   },
   {
     "id": "questions-ownership-u5-10",
     "title": "Questions: Ownership (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Ownership subcategory within Questions. Includes 6 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Ownership subcategory within Questions. Includes 2 card(s).",
     "file": "questions-ownership-u5-10.json"
   },
   {
@@ -1814,7 +1814,7 @@
   {
     "id": "requests-food-and-drink-u5-10",
     "title": "Requests: Food & Drink (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Food & Drink subcategory within Requests. Includes 4 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Food & Drink subcategory within Requests. Includes 3 card(s).",
     "file": "requests-food-and-drink-u5-10.json"
   },
   {
@@ -1850,7 +1850,7 @@
   {
     "id": "requests-offering-u5-10",
     "title": "Requests: Offering (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Offering subcategory within Requests. Includes 2 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Offering subcategory within Requests. Includes 1 card(s).",
     "file": "requests-offering-u5-10.json"
   },
   {
@@ -1862,7 +1862,7 @@
   {
     "id": "requests-social-u1-5",
     "title": "Requests: Social (Usefulness 1-5)",
-    "description": "Traveler usefulness 1-5/10 phrases for the Social subcategory within Requests. Includes 3 card(s).",
+    "description": "Traveler usefulness 1-5/10 phrases for the Social subcategory within Requests. Includes 1 card(s).",
     "file": "requests-social-u1-5.json"
   },
   {
@@ -1964,7 +1964,7 @@
   {
     "id": "shopping-and-money-asking-prices-u5-10",
     "title": "Shopping & Money: Asking Prices (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Asking Prices subcategory within Shopping & Money. Includes 4 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Asking Prices subcategory within Shopping & Money. Includes 3 card(s).",
     "file": "shopping-and-money-asking-prices-u5-10.json"
   },
   {
@@ -2228,13 +2228,13 @@
   {
     "id": "transportation-bus-u5-10",
     "title": "Transportation: Bus (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Bus subcategory within Transportation. Includes 7 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Bus subcategory within Transportation. Includes 6 card(s).",
     "file": "transportation-bus-u5-10.json"
   },
   {
     "id": "transportation-buying-tickets-u5-10",
     "title": "Transportation: Buying Tickets (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Buying Tickets subcategory within Transportation. Includes 9 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Buying Tickets subcategory within Transportation. Includes 7 card(s).",
     "file": "transportation-buying-tickets-u5-10.json"
   },
   {
@@ -2264,7 +2264,7 @@
   {
     "id": "transportation-taxi-u5-10",
     "title": "Transportation: Taxi (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Taxi subcategory within Transportation. Includes 6 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Taxi subcategory within Transportation. Includes 5 card(s).",
     "file": "transportation-taxi-u5-10.json"
   },
   {
@@ -2288,7 +2288,7 @@
   {
     "id": "transportation-train-u5-10",
     "title": "Transportation: Train (Usefulness 5-10)",
-    "description": "Traveler usefulness 5-10/10 phrases for the Train subcategory within Transportation. Includes 7 card(s).",
+    "description": "Traveler usefulness 5-10/10 phrases for the Train subcategory within Transportation. Includes 6 card(s).",
     "file": "transportation-train-u5-10.json"
   },
   {

--- a/decks/questions-identification-u5-10.json
+++ b/decks/questions-identification-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "questions-identification-u5-10",
   "title": "Questions: Identification (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Questions. Includes 4 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Identification subcategory within Questions. Includes 2 card(s).",
   "cards": [
-    {
-      "english": "What is this?",
-      "romaji": "Kore wa nan desu ka.",
-      "japanese": "これは何ですか。"
-    },
     {
       "english": "What is this?",
       "romaji": "Kore wa nan desu ka.",
@@ -17,11 +12,6 @@
       "english": "What is that?",
       "romaji": "Sore wa nan desu ka.",
       "japanese": "それは何ですか。"
-    },
-    {
-      "english": "What is this?",
-      "romaji": "Kore wa nan desu ka.",
-      "japanese": "これは何ですか。"
     }
   ]
 }

--- a/decks/questions-opinion-u5-10.json
+++ b/decks/questions-opinion-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "questions-opinion-u5-10",
   "title": "Questions: Opinion (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Opinion subcategory within Questions. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Opinion subcategory within Questions. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "How is the taste?",
-      "romaji": "Aji wa do desu ka.",
-      "japanese": "味はどうですか。"
-    },
     {
       "english": "How is the taste?",
       "romaji": "Aji wa do desu ka.",

--- a/decks/questions-ownership-u1-5.json
+++ b/decks/questions-ownership-u1-5.json
@@ -1,28 +1,8 @@
 {
   "id": "questions-ownership-u1-5",
   "title": "Questions: Ownership (Usefulness 1-5)",
-  "description": "Traveler usefulness 1-5/10 phrases for the Ownership subcategory within Questions. Includes 5 card(s).",
+  "description": "Traveler usefulness 1-5/10 phrases for the Ownership subcategory within Questions. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
     {
       "english": "Huh? Is this mine?",
       "romaji": "Are? Kore wa watashi no desu ka.",

--- a/decks/questions-ownership-u5-10.json
+++ b/decks/questions-ownership-u5-10.json
@@ -1,32 +1,12 @@
 {
   "id": "questions-ownership-u5-10",
   "title": "Questions: Ownership (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Ownership subcategory within Questions. Includes 6 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Ownership subcategory within Questions. Includes 2 card(s).",
   "cards": [
     {
       "english": "Is this yours?",
       "romaji": "Kore wa anata no desu ka?",
       "japanese": "これはあなたのですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
-    },
-    {
-      "english": "Huh? Is this mine?",
-      "romaji": "Are? Kore wa watashi no desu ka.",
-      "japanese": "あれ？これは私のですか？"
     },
     {
       "english": "Huh? Is this mine?",

--- a/decks/requests-food-and-drink-u5-10.json
+++ b/decks/requests-food-and-drink-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "requests-food-and-drink-u5-10",
   "title": "Requests: Food & Drink (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Food & Drink subcategory within Requests. Includes 4 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Food & Drink subcategory within Requests. Includes 3 card(s).",
   "cards": [
-    {
-      "english": "Can I have some water, please?",
-      "romaji": "Mizu o kudasai.",
-      "japanese": "水をください。"
-    },
     {
       "english": "Can I have some water, please?",
       "romaji": "Mizu o kudasai.",

--- a/decks/requests-offering-u5-10.json
+++ b/decks/requests-offering-u5-10.json
@@ -1,13 +1,8 @@
 {
   "id": "requests-offering-u5-10",
   "title": "Requests: Offering (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Offering subcategory within Requests. Includes 2 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Offering subcategory within Requests. Includes 1 card(s).",
   "cards": [
-    {
-      "english": "Please have some more.",
-      "romaji": "Motto tabete kudasai.",
-      "japanese": "もっと食べてください。"
-    },
     {
       "english": "Please have some more.",
       "romaji": "Motto tabete kudasai.",

--- a/decks/requests-social-u1-5.json
+++ b/decks/requests-social-u1-5.json
@@ -1,21 +1,11 @@
 {
   "id": "requests-social-u1-5",
   "title": "Requests: Social (Usefulness 1-5)",
-  "description": "Traveler usefulness 1-5/10 phrases for the Social subcategory within Requests. Includes 3 card(s).",
+  "description": "Traveler usefulness 1-5/10 phrases for the Social subcategory within Requests. Includes 1 card(s).",
   "cards": [
     {
       "english": "Your signature (autograph), please.",
       "romaji": "Sain wo onegai shimasu.",
-      "japanese": "サインをお願いします。"
-    },
-    {
-      "english": "Your signature (autograph), please.",
-      "romaji": "Sain wo onegai shimasu.",
-      "japanese": "サインをお願いします。"
-    },
-    {
-      "english": "Your signature (autograph), please.",
-      "romaji": "Sain o onegai shimasu.",
       "japanese": "サインをお願いします。"
     }
   ]

--- a/decks/shopping-and-money-asking-prices-u5-10.json
+++ b/decks/shopping-and-money-asking-prices-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "shopping-and-money-asking-prices-u5-10",
   "title": "Shopping & Money: Asking Prices (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Asking Prices subcategory within Shopping & Money. Includes 4 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Asking Prices subcategory within Shopping & Money. Includes 3 card(s).",
   "cards": [
     {
       "english": "How much?",
@@ -17,11 +17,6 @@
       "english": "How much is that?",
       "romaji": "Sore wa ikura desu ka?",
       "japanese": "それはいくらですか？"
-    },
-    {
-      "english": "How much?",
-      "romaji": "Ikura?",
-      "japanese": "いくら？"
     }
   ]
 }

--- a/decks/transportation-bus-u5-10.json
+++ b/decks/transportation-bus-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "transportation-bus-u5-10",
   "title": "Transportation: Bus (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Bus subcategory within Transportation. Includes 7 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Bus subcategory within Transportation. Includes 6 card(s).",
   "cards": [
     {
       "english": "Where is the bus stop?",
@@ -27,11 +27,6 @@
       "english": "Is Narita Airport the next stop?",
       "romaji": "Narita kuko wa tsugi desu ka?",
       "japanese": "成田空港は次ですか？"
-    },
-    {
-      "english": "I'll get off at the next bus stop.",
-      "romaji": "Watashi wa, tsugi no basutei de orimasu.",
-      "japanese": "私は、次のバス停で降ります。"
     },
     {
       "english": "For long-distance journeys, all-day and all-night buses are also available.",

--- a/decks/transportation-buying-tickets-u5-10.json
+++ b/decks/transportation-buying-tickets-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "transportation-buying-tickets-u5-10",
   "title": "Transportation: Buying Tickets (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Buying Tickets subcategory within Transportation. Includes 9 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Buying Tickets subcategory within Transportation. Includes 7 card(s).",
   "cards": [
     {
       "english": "One ticket to Narita Airport, please.",
@@ -24,11 +24,6 @@
       "japanese": "東京駅までの切符をください。"
     },
     {
-      "english": "Four tickets, please.",
-      "romaji": "Kippu o yon-mai kudasai.",
-      "japanese": "切符を四枚ください。"
-    },
-    {
       "english": "One ticket to Tokyo Station please.",
       "romaji": "Tokyo eki made no kippu wo ichi-mai kudasai.",
       "japanese": "東京駅までの切符を一枚ください。"
@@ -42,11 +37,6 @@
       "english": "Two tickets please.",
       "romaji": "Ni mai kippu wo kudasai.",
       "japanese": "二枚切符をください。"
-    },
-    {
-      "english": "One ticket to Tokyo Station please.",
-      "romaji": "Tokyo eki made no kippu wo ichi-mai kudasai.",
-      "japanese": "東京駅までの切符を一枚ください。"
     }
   ]
 }

--- a/decks/transportation-taxi-u5-10.json
+++ b/decks/transportation-taxi-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "transportation-taxi-u5-10",
   "title": "Transportation: Taxi (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Taxi subcategory within Transportation. Includes 6 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Taxi subcategory within Transportation. Includes 5 card(s).",
   "cards": [
     {
       "english": "Where is the taxi stand?",
@@ -12,11 +12,6 @@
       "english": "I would like to go to Tokyo Station.",
       "romaji": "Tokyo eki e onegai shimasu.",
       "japanese": "東京駅へお願いします。"
-    },
-    {
-      "english": "Where is the taxi stand?",
-      "romaji": "Takushi noriba wa doko desu ka?",
-      "japanese": "タクシー乗り場はどこですか？"
     },
     {
       "english": "Where is the taxi terminal?",

--- a/decks/transportation-train-u5-10.json
+++ b/decks/transportation-train-u5-10.json
@@ -1,7 +1,7 @@
 {
   "id": "transportation-train-u5-10",
   "title": "Transportation: Train (Usefulness 5-10)",
-  "description": "Traveler usefulness 5-10/10 phrases for the Train subcategory within Transportation. Includes 7 card(s).",
+  "description": "Traveler usefulness 5-10/10 phrases for the Train subcategory within Transportation. Includes 6 card(s).",
   "cards": [
     {
       "english": "Where is the ticket gate?",
@@ -12,11 +12,6 @@
       "english": "Will this train go to Tokyo Station?",
       "romaji": "Tokyo eki made ikimasu ka?",
       "japanese": "東京駅まで行きますか？"
-    },
-    {
-      "english": "The next station is Osaka.",
-      "romaji": "Tsugi no eki wa Osaka desu.",
-      "japanese": "次の駅は大阪です。"
     },
     {
       "english": "The next station is Osaka.",

--- a/generate_decks.py
+++ b/generate_decks.py
@@ -13,12 +13,13 @@ import json
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 ROOT = Path(__file__).parent
 TSV_PATH = ROOT / "phrases.tsv"
 DECKS_DIR = ROOT / "decks"
 MANIFEST_PATH = DECKS_DIR / "manifest.json"
+DEFAULT_PRESETS_PATH = DECKS_DIR / "default-presets.json"
 
 
 def slugify(text: str) -> str:
@@ -35,6 +36,83 @@ USEFULNESS_BUCKETS: Tuple[Tuple[str, int, int], ...] = (
     ("1-5", 1, 5),
     ("5-10", 5, 10),
 )
+
+DEFAULT_PRESETS_SPEC: List[Dict[str, Any]] = [
+    {"name": "Politeness & Gratitude", "categories": ["Apologies", "Polite Expressions", "Gratitude", "Farewells", "Common Phrases"]},
+    {"name": "Greetings & Introductions", "categories": ["Greetings", "Introductions", "Social", "Feelings", "Small Talk"]},
+    {"name": "Nightlife Connections", "categories": ["Entertainment", "Social", "Requests", "Preferences"]},
+    {"name": "Communication Lifelines", "categories": ["Communication Help", "Language Help", "Information"]},
+    {"name": "Questions & Responses", "categories": ["Questions", "Common Responses"]},
+    {"name": "Requests & Preferences", "categories": ["Requests", "Preferences", "Polite Expressions"]},
+    {"name": "Navigation Basics", "categories": ["Directions", "Asking for Directions", "Travel", "Location"]},
+    {"name": "Transit Logistics", "categories": ["Transportation", "Business Hours"]},
+    {"name": "Counting & Comparisons", "categories": ["Counting", "Comparisons"]},
+    {"name": "Time & Schedules", "categories": ["Telling Time", "Making Plans"]},
+    {"name": "Hotel & Concierge", "categories": ["At the Hotel", "Renting", "Information", "Lost & Found"]},
+    {"name": "Postal & Practicalities", "categories": ["Postal Service", "Money Exchange", "Money", "Business Hours"]},
+    {"name": "Shopping Essentials", "categories": ["Shopping", "Shopping & Money", "Clothing"]},
+    {"name": "Market Interactions", "categories": ["Shopping & Restaurants", "Money", "Money Exchange"]},
+    {"name": "Dining Out", "categories": ["At a Restaurant", "Shopping & Restaurants"]},
+    {"name": "Dietary Support", "categories": ["Dietary Needs", "Health (Allergies)"]},
+    {"name": "Food Adventures", "categories": ["Food"]},
+    {"name": "Health Essentials", "categories": ["Health", "Health (Pharmacy)"]},
+    {"name": "Body Focus", "categories": ["Health (Body Parts)"]},
+    {"name": "Emergency Response", "categories": ["Emergency", "Rules", "Health (Pharmacy)"]},
+    {"name": "Connected Traveler", "categories": ["Internet & Technology", "Communication Help", "Travel"]},
+    {"name": "Service Errands", "categories": ["Postal Service", "Lost & Found", "Information"]},
+    {"name": "Customer Care", "categories": ["Shopping & Restaurants", "Polite Expressions", "Requests"]},
+    {"name": "Vocabulary: Food Staples", "decks": ["vocabulary-food-u5-10"]},
+    {"name": "Vocabulary: Places & Routes", "decks": ["vocabulary-places-and-things-u5-10"]},
+    {
+        "name": "Vocabulary: Concepts & Expressions",
+        "decks": [
+            "vocabulary-concepts-u5-10",
+            "vocabulary-exclamations-u5-10",
+            "vocabulary-animals-u5-10",
+            "nature-plants-u5-10",
+            "weather-temperature-u5-10",
+        ],
+    },
+    {"name": "Vocabulary: Action Verbs", "decks": ["vocabulary-verbs-u5-10"]},
+    {
+        "name": "Vocabulary: Descriptive Language",
+        "categories": ["Descriptions"],
+        "decks": ["vocabulary-adjectives-u5-10"],
+    },
+    {"name": "Vocabulary: Everyday Items", "decks": ["vocabulary-other-u5-10"]},
+    {
+        "name": "Vocabulary: People Skills",
+        "categories": ["Introductions", "Social"],
+        "decks": ["vocabulary-people-u5-10"],
+    },
+    {
+        "name": "Vocabulary: Number Sense",
+        "decks": ["counting-people-u5-10", "counting-food-and-drink-u5-10", "counting-objects-u5-10"],
+    },
+    {"name": "Travel Paperwork", "categories": ["Travel", "Postal Service", "Money Exchange", "Business Hours"]},
+    {
+        "name": "Hospital Visit Prep",
+        "categories": ["Health", "Health (Pharmacy)", "Health (Allergies)"],
+    },
+    {
+        "name": "Medical Emergencies",
+        "categories": ["Emergency", "Health (Pharmacy)", "Communication Help"],
+    },
+    {"name": "Safety Briefings", "categories": ["Emergency", "Communication Help"]},
+    {"name": "Transit Tickets", "categories": ["Transportation", "Money Exchange"]},
+    {
+        "name": "Dining Requests",
+        "decks": [
+            "at-a-restaurant-ordering-u5-10",
+            "at-a-restaurant-stating-preferences-u5-10",
+            "dietary-needs-requests-u5-10",
+            "preferences-likes-u5-10",
+            "preferences-dislikes-u5-10",
+        ],
+    },
+    {"name": "Guided Tours", "categories": ["Directions", "Information"]},
+    {"name": "Local Services", "categories": ["Postal Service", "Renting", "Money Exchange", "Information"]},
+]
 
 
 def load_phrases() -> Dict[Tuple[str, str, int], List[Dict[str, str]]]:
@@ -69,6 +147,48 @@ def load_phrases() -> Dict[Tuple[str, str, int], List[Dict[str, str]]]:
     return groupings
 
 
+def normalize_card_key(card: Dict[str, str]) -> Tuple[str, ...]:
+    """Build a normalization key so duplicate phrases can be removed."""
+
+    def normalize_latin(text: str) -> str:
+        return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+    english = normalize_latin(card.get("english", ""))
+    if english:
+        return ("en", english)
+
+    japanese = card.get("japanese", "").strip()
+    if japanese:
+        cleaned = re.sub(r"[\s\u3000。．\.?!！？、,，]+", "", japanese)
+        if cleaned:
+            return ("ja", cleaned)
+
+    romaji = normalize_latin(card.get("romaji", ""))
+    if romaji:
+        return ("ro", romaji)
+
+    fallback = (
+        card.get("english", ""),
+        card.get("romaji", ""),
+        card.get("japanese", ""),
+    )
+    return ("fallback",) + fallback
+
+
+def deduplicate_cards(cards: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Remove duplicate cards while preserving the original order."""
+
+    seen = set()
+    unique_cards: List[Dict[str, str]] = []
+    for card in cards:
+        key = normalize_card_key(card)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_cards.append(card)
+    return unique_cards
+
+
 def write_deck(deck_id: str, title: str, description: str, cards: List[Dict[str, str]]) -> None:
     deck_path = DECKS_DIR / f"{deck_id}.json"
     deck_data = {
@@ -79,6 +199,40 @@ def write_deck(deck_id: str, title: str, description: str, cards: List[Dict[str,
     }
     deck_path.write_text(json.dumps(deck_data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
+
+
+def write_default_presets(
+    category_map: Dict[str, List[str]],
+    available_decks: Set[str]
+) -> None:
+    resolved: List[Dict[str, Any]] = []
+    for spec in DEFAULT_PRESETS_SPEC:
+        name = spec.get("name")
+        if not name:
+            continue
+
+        deck_ids: List[str] = []
+        for category in spec.get("categories", []):
+            deck_ids.extend(category_map.get(category, []))
+        deck_ids.extend(spec.get("decks", []))
+
+        unique: List[str] = []
+        seen: Set[str] = set()
+        for deck_id in deck_ids:
+            if deck_id in seen or deck_id not in available_decks:
+                continue
+            seen.add(deck_id)
+            unique.append(deck_id)
+
+        if not unique:
+            continue
+
+        resolved.append({"name": name, "deckIds": unique})
+
+    DEFAULT_PRESETS_PATH.write_text(
+        json.dumps(resolved, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
 
 
 def main() -> None:
@@ -96,6 +250,8 @@ def main() -> None:
         path.unlink()
 
     manifest_entries = []
+    category_map: Dict[str, List[str]] = defaultdict(list)
+    available_decks: Set[str] = set()
 
     bucket_lookup = {label: (lower, upper) for label, lower, upper in USEFULNESS_BUCKETS}
     bucket_order = {label: index for index, (label, *_rest) in enumerate(USEFULNESS_BUCKETS)}
@@ -119,7 +275,7 @@ def main() -> None:
             bucket_order.get(item[2], len(USEFULNESS_BUCKETS)),
         ),
     ):
-        cards = combined[(category, subcategory, label)]
+        cards = deduplicate_cards(combined[(category, subcategory, label)])
         if not cards:
             continue
 
@@ -132,6 +288,9 @@ def main() -> None:
         )
 
         write_deck(deck_slug, title, description, cards)
+        available_decks.add(deck_slug)
+        if label == "5-10":
+            category_map[category].append(deck_slug)
 
         manifest_entries.append({
             "id": deck_slug,
@@ -141,6 +300,7 @@ def main() -> None:
         })
 
     MANIFEST_PATH.write_text(json.dumps(manifest_entries, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    write_default_presets(category_map, available_decks)
 
 
 if __name__ == "__main__":

--- a/site.css
+++ b/site.css
@@ -235,6 +235,13 @@ body {
   min-width: 0;
 }
 
+.preset-name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
 .preset-name {
   font-size: 0.95rem;
   font-weight: 600;
@@ -245,6 +252,18 @@ body {
 .preset-count {
   font-size: 0.8rem;
   color: rgba(248, 250, 252, 0.65);
+}
+
+.preset-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(129, 140, 248, 0.25);
+  color: rgba(248, 250, 252, 0.8);
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .preset-actions {
@@ -287,7 +306,7 @@ body {
 
 .deck-list {
   display: grid;
-  gap: 10px;
+  gap: 6px;
 }
 
 .deck-empty {
@@ -302,15 +321,15 @@ body {
   text-align: left;
   background: rgba(15, 23, 42, 0.35);
   border: 1px solid transparent;
-  border-radius: 16px;
-  padding: 16px;
+  border-radius: 12px;
+  padding: 8px 10px;
   color: inherit;
   font: inherit;
   cursor: pointer;
   transition: transform 0.2s ease, border 0.2s ease, background 0.3s ease;
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
+  align-items: center;
+  gap: 8px;
 }
 
 .deck-button:hover,
@@ -326,22 +345,34 @@ body {
 }
 
 .deck-option input[type="checkbox"] {
-  width: 20px;
-  height: 20px;
-  margin: 4px 0 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
   accent-color: var(--accent);
   flex-shrink: 0;
 }
 
-.deck-option-content h3 {
-  margin: 0 0 6px;
-  font-size: 1.05rem;
+.deck-option-content {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
 }
 
-.deck-option-content p {
+.deck-option-title {
   margin: 0;
-  font-size: 0.85rem;
-  color: rgba(248, 250, 252, 0.75);
+  font-size: 0.9rem;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.deck-option-count {
+  font-size: 0.7rem;
+  color: rgba(248, 250, 252, 0.65);
+  flex-shrink: 0;
 }
 
 .sidebar .pill-button.ghost {


### PR DESCRIPTION
## Summary
- collapse duplicate detection onto normalized English text so repeated phrases are removed across generated decks
- regenerate all affected deck JSON plus manifest/preset data to reflect the stricter dedupe logic
- tighten deck picker styling so each option is more compact while keeping counts visible

## Testing
- python generate_decks.py

------
https://chatgpt.com/codex/tasks/task_e_68d31a6088848325af647f0d76e2307f