### PR TITLE
Refocus the study app on phrase filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,38 +22,51 @@
             <p>Learn useful phrases before your next adventure.</p>
           </div>
         </div>
-        <div class="deck-search">
-          <label class="deck-search-label" for="deck-filter">Filter decks</label>
-          <input type="search" id="deck-filter" placeholder="Search decks…" />
-        </div>
+        <section class="phrase-search">
+          <div class="phrase-search-header">
+            <label class="phrase-search-label" for="phrase-filter">Filter phrases</label>
+            <button id="show-all-phrases" type="button" class="pill-button ghost small">Show all</button>
+          </div>
+          <input
+            type="search"
+            id="phrase-filter"
+            placeholder="Type words or #tags to find phrases…"
+            autocomplete="off"
+          />
+          <p class="phrase-search-help">Click a tag to add it to your filter.</p>
+          <div class="tag-list" id="tag-list" aria-label="Available tags"></div>
+        </section>
+        <section class="phrase-panel" id="phrase-panel">
+          <div class="phrase-hint" id="phrase-hint">Start typing to browse phrases or choose Show all.</div>
+          <div class="phrase-list" id="phrase-list" role="list"></div>
+        </section>
         <section class="deck-selection-panel">
-          <div class="selection-summary" id="selection-summary">No decks selected yet.</div>
+          <div class="selection-summary" id="selection-summary">No phrases selected yet.</div>
           <div class="selection-actions">
             <button id="study-selected" type="button" class="pill-button primary" disabled>
-              Study selected decks
+              Study selected phrases
             </button>
             <button id="clear-selection" type="button" class="pill-button ghost" disabled>Clear</button>
           </div>
         </section>
         <section class="preset-panel">
           <div class="preset-header">
-            <h3>Presets</h3>
-            <p class="preset-help">Save frequently used deck combinations for quick access.</p>
+            <h3>Decks</h3>
+            <p class="preset-help">Save phrase selections as reusable decks.</p>
           </div>
           <div class="preset-list" id="preset-list"></div>
           <form id="preset-form" class="preset-form">
-            <label class="sr-only" for="preset-name">Preset name</label>
-            <input type="text" id="preset-name" name="preset-name" placeholder="Name this preset" autocomplete="off" />
-            <button type="submit" class="pill-button ghost small">Save preset</button>
+            <label class="sr-only" for="preset-name">Deck name</label>
+            <input type="text" id="preset-name" name="preset-name" placeholder="Name this deck" autocomplete="off" />
+            <button type="submit" class="pill-button ghost small">Save deck</button>
           </form>
         </section>
-        <nav class="deck-list" id="deck-list" aria-label="Deck list"></nav>
       </aside>
       <main class="main">
         <section class="deck-header" id="deck-header">
           <div class="deck-meta">
-            <h2 id="deck-title">Choose decks</h2>
-            <p id="deck-description">Pick one or more of the travel-focused decks to begin studying.</p>
+            <h2 id="deck-title">Study phrases</h2>
+            <p id="deck-description">Select phrases from the list to build a custom study session.</p>
           </div>
           <div class="deck-progress" id="deck-progress" hidden>
             <div class="progress-label">Progress</div>
@@ -63,29 +76,12 @@
             <div class="progress-count" id="progress-count"></div>
           </div>
         </section>
-        <section class="card-filters" id="card-filters" aria-label="Phrase filters">
-          <div class="card-filter">
-            <label for="card-search">Search phrases</label>
-            <input type="search" id="card-search" placeholder="Search English, 日本語, or tags" />
-          </div>
-          <div class="card-filter">
-            <label for="usefulness-filter">Minimum usefulness</label>
-            <select id="usefulness-filter">
-              <option value="">Any rating</option>
-              <option value="3">3+</option>
-              <option value="5">5+</option>
-              <option value="7">7+</option>
-              <option value="9">9+</option>
-            </select>
-          </div>
-          <button id="clear-card-filters" type="button" class="pill-button ghost small">Clear filters</button>
-        </section>
         <section class="card-stage" aria-live="polite">
           <div class="card" id="study-card" data-side="front">
             <div class="card-inner" id="card-inner">
               <article class="card-face card-front" aria-label="Card front">
                 <header>English phrase</header>
-                <p id="card-front-text">Select decks to begin.</p>
+                <p id="card-front-text">Select phrases to begin.</p>
               </article>
               <article class="card-face card-back" aria-label="Card back">
                 <header>Japanese phrase</header>

--- a/site.css
+++ b/site.css
@@ -143,20 +143,27 @@ body {
   color: rgba(248, 250, 252, 0.78);
 }
 
-.deck-search {
+.phrase-search {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
-.deck-search-label {
+.phrase-search-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.phrase-search-label {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(248, 250, 252, 0.55);
 }
 
-#deck-filter {
+#phrase-filter {
   border: none;
   border-radius: 12px;
   padding: 10px 14px;
@@ -165,8 +172,201 @@ body {
   color: var(--text-inverse);
 }
 
-#deck-filter::placeholder {
+#phrase-filter::placeholder {
   color: rgba(248, 250, 252, 0.55);
+}
+
+.phrase-search-help {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(248, 250, 252, 0.6);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.3);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.tag-chip {
+  font: inherit;
+  font-size: 0.75rem;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(248, 250, 252, 0.85);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease;
+}
+
+.tag-chip:hover,
+.tag-chip:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(99, 102, 241, 0.45);
+}
+
+.tag-chip.is-active {
+  background: rgba(99, 102, 241, 0.6);
+  border-color: rgba(165, 180, 252, 0.9);
+  box-shadow: 0 8px 18px rgba(99, 102, 241, 0.35);
+}
+
+.phrase-panel {
+  background: rgba(15, 23, 42, 0.3);
+  border-radius: 18px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.phrase-hint {
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.7);
+  margin: 0;
+}
+
+.phrase-list {
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.phrase-panel.is-active .phrase-list {
+  display: flex;
+}
+
+.phrase-panel.is-active .phrase-hint {
+  display: none;
+}
+
+.phrase-empty {
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.35);
+  color: rgba(248, 250, 252, 0.75);
+  font-size: 0.85rem;
+}
+
+.phrase-item {
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-inverse);
+  overflow: hidden;
+  border: 1px solid transparent;
+}
+
+.phrase-item[open] {
+  border-color: rgba(129, 140, 248, 0.35);
+  box-shadow: 0 14px 28px rgba(99, 102, 241, 0.22);
+}
+
+.phrase-item.is-selected {
+  border-color: rgba(129, 140, 248, 0.75);
+  background: rgba(99, 102, 241, 0.32);
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.38);
+}
+
+.phrase-summary {
+  list-style: none;
+  margin: 0;
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  cursor: pointer;
+}
+
+.phrase-summary::-webkit-details-marker,
+.phrase-summary::marker {
+  display: none;
+}
+
+.phrase-summary-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.phrase-summary-english {
+  font-weight: 600;
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.phrase-summary-japanese {
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.75);
+  word-break: break-word;
+}
+
+.phrase-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 16px 16px;
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.phrase-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.phrase-romaji {
+  font-size: 0.9rem;
+  color: rgba(165, 180, 252, 0.95);
+}
+
+.phrase-japanese {
+  font-size: 1rem;
+  font-family: "Noto Sans JP", system-ui, sans-serif;
+}
+
+.phrase-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.phrase-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.phrase-tag {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.5);
+  color: rgba(248, 250, 252, 0.75);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+}
+
+.phrase-toggle.is-remove {
+  background: rgba(248, 113, 113, 0.25);
+  border-color: rgba(248, 113, 113, 0.5);
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.phrase-toggle.is-remove:not(:disabled):hover,
+.phrase-toggle.is-remove:not(:disabled):focus-visible {
+  background: rgba(239, 68, 68, 0.45);
 }
 
 .deck-selection-panel,
@@ -304,76 +504,6 @@ body {
   color: rgba(248, 250, 252, 0.55);
 }
 
-.deck-list {
-  display: grid;
-  gap: 6px;
-}
-
-.deck-empty {
-  padding: 18px;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.35);
-  color: rgba(248, 250, 252, 0.8);
-  text-align: center;
-}
-
-.deck-button {
-  text-align: left;
-  background: rgba(15, 23, 42, 0.35);
-  border: 1px solid transparent;
-  border-radius: 12px;
-  padding: 8px 10px;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-  transition: transform 0.2s ease, border 0.2s ease, background 0.3s ease;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.deck-button:hover,
-.deck-button:focus-visible {
-  border-color: rgba(148, 163, 184, 0.55);
-  transform: translateY(-2px);
-}
-
-.deck-option.is-selected {
-  background: rgba(99, 102, 241, 0.35);
-  border-color: rgba(129, 140, 248, 0.9);
-  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.35);
-}
-
-.deck-option input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  margin: 0;
-  accent-color: var(--accent);
-  flex-shrink: 0;
-}
-
-.deck-option-content {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-  width: 100%;
-}
-
-.deck-option-title {
-  margin: 0;
-  font-size: 0.9rem;
-  font-weight: 600;
-  flex: 1;
-  min-width: 0;
-  word-break: break-word;
-}
-
-.deck-option-count {
-  font-size: 0.7rem;
-  color: rgba(248, 250, 252, 0.65);
-  flex-shrink: 0;
-}
 
 .sidebar .pill-button.ghost {
   background: rgba(15, 23, 42, 0.4);


### PR DESCRIPTION
## Summary
- replace the sidebar deck picker with a phrase filter, tag chips, and a collapsible phrase list
- allow selecting phrases directly, saving those selections as decks, and persisting them per-browser
- load all phrases up front, support multi-tag filtering, and update the study header/card defaults to match the new flow

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3eb7d776c832598b48e7942d83258