### PR TITLE
Improve filtering UI and phrase list layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,17 @@
           </div>
         </div>
         <section class="phrase-search">
+          <div class="tag-filter-group">
+            <label class="phrase-search-label" for="tag-filter">Filter tags</label>
+            <input
+              type="search"
+              id="tag-filter"
+              placeholder="Search tags…"
+              autocomplete="off"
+            />
+          </div>
+          <p class="phrase-search-help">Search and click tags to add them to your phrase filter.</p>
+          <div class="tag-list" id="tag-list" aria-label="Available tags"></div>
           <div class="phrase-search-header">
             <label class="phrase-search-label" for="phrase-filter">Filter phrases</label>
             <button id="show-all-phrases" type="button" class="pill-button ghost small">Show all</button>
@@ -33,8 +44,23 @@
             placeholder="Type words or #tags to find phrases…"
             autocomplete="off"
           />
-          <p class="phrase-search-help">Click a tag to add it to your filter.</p>
-          <div class="tag-list" id="tag-list" aria-label="Available tags"></div>
+          <div class="usefulness-filter">
+            <label class="phrase-search-label" for="usefulness-filter">Traveler usability</label>
+            <select id="usefulness-filter" name="usefulness-filter">
+              <option value="0">Any rating</option>
+              <option value="1">At least 1/10</option>
+              <option value="2">At least 2/10</option>
+              <option value="3">At least 3/10</option>
+              <option value="4">At least 4/10</option>
+              <option value="5">At least 5/10</option>
+              <option value="6">At least 6/10</option>
+              <option value="7">At least 7/10</option>
+              <option value="8">At least 8/10</option>
+              <option value="9">At least 9/10</option>
+              <option value="10">10/10 only</option>
+              <option value="unrated">Unrated only</option>
+            </select>
+          </div>
         </section>
         <section class="phrase-panel" id="phrase-panel">
           <div class="phrase-hint" id="phrase-hint">Start typing to browse phrases or choose Show all.</div>

--- a/site.css
+++ b/site.css
@@ -146,7 +146,14 @@ body {
 .phrase-search {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
+}
+
+.tag-filter-group,
+.usefulness-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .phrase-search-header {
@@ -163,7 +170,9 @@ body {
   color: rgba(248, 250, 252, 0.55);
 }
 
-#phrase-filter {
+#tag-filter,
+#phrase-filter,
+#usefulness-filter {
   border: none;
   border-radius: 12px;
   padding: 10px 14px;
@@ -172,7 +181,34 @@ body {
   color: var(--text-inverse);
 }
 
+#tag-filter::placeholder,
 #phrase-filter::placeholder {
+  color: rgba(248, 250, 252, 0.55);
+}
+
+#usefulness-filter {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding-right: 40px;
+  appearance: none;
+  cursor: pointer;
+}
+
+#usefulness-filter option {
+  color: var(--text-primary);
+}
+
+.usefulness-filter {
+  position: relative;
+}
+
+.usefulness-filter::after {
+  content: '▾';
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.75rem;
   color: rgba(248, 250, 252, 0.55);
 }
 
@@ -191,6 +227,8 @@ body {
   background: rgba(15, 23, 42, 0.3);
   max-height: 200px;
   overflow-y: auto;
+  align-items: flex-start;
+  align-content: flex-start;
 }
 
 .tag-chip {
@@ -203,6 +241,16 @@ body {
   color: rgba(248, 250, 252, 0.85);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease;
+}
+
+.tag-empty {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(248, 250, 252, 0.75);
+  font-size: 0.8rem;
+  text-align: center;
 }
 
 .tag-chip:hover,
@@ -239,6 +287,7 @@ body {
   max-height: 360px;
   overflow-y: auto;
   padding-right: 4px;
+  align-items: stretch;
 }
 
 .phrase-panel.is-active .phrase-list {
@@ -263,6 +312,9 @@ body {
   color: var(--text-inverse);
   overflow: hidden;
   border: 1px solid transparent;
+  width: 100%;
+  box-sizing: border-box;
+  flex: 0 0 auto;
 }
 
 .phrase-item[open] {
@@ -338,15 +390,38 @@ body {
 .phrase-meta {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 12px;
   justify-content: space-between;
+}
+
+.phrase-meta-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.phrase-usefulness {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(165, 180, 252, 0.85);
+}
+
+.phrase-usefulness.is-unrated {
+  color: rgba(248, 250, 252, 0.6);
 }
 
 .phrase-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.phrase-toggle {
+  align-self: flex-start;
 }
 
 .phrase-tag {


### PR DESCRIPTION
## Summary
- add a searchable tag list and move the phrase search beneath it
- support traveler usability filtering and display the rating on each phrase while matching phrases that contain any selected tag
- tighten phrase list styling so rows fill the container and show helpful empty states

## Testing
- No automated tests (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3f8caab708325aa0a01623254b54e