### PR TITLE
Add button to add all filtered phrases

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
             <button id="study-selected" type="button" class="pill-button primary" disabled>
               Study selected phrases
             </button>
+            <button id="add-filtered" type="button" class="pill-button ghost" disabled>
+              Add all filtered
+            </button>
             <button id="clear-selection" type="button" class="pill-button ghost" disabled>Clear</button>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add an **Add all filtered** control to the selection actions panel
- implement logic to bulk select the currently filtered phrases and manage its enabled state

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d3ff597fa483258ea4c7d674e6ed4e