### PR TITLE
Restyle deck selection buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,13 +69,13 @@
         <section class="deck-selection-panel">
           <div class="selection-summary" id="selection-summary">No phrases selected yet.</div>
           <div class="selection-actions">
-            <button id="study-selected" type="button" class="pill-button primary" disabled>
+            <button id="study-selected" type="button" class="pill-button primary small" disabled>
               Study selected phrases
             </button>
-            <button id="add-filtered" type="button" class="pill-button ghost" disabled>
+            <button id="add-filtered" type="button" class="pill-button ghost small" disabled>
               Add all filtered
             </button>
-            <button id="clear-selection" type="button" class="pill-button ghost" disabled>Clear</button>
+            <button id="clear-selection" type="button" class="pill-button ghost small" disabled>Clear</button>
           </div>
         </section>
         <section class="preset-panel">

--- a/site.css
+++ b/site.css
@@ -93,6 +93,10 @@ body {
   font-size: 0.8rem;
 }
 
+.pill-button.primary.small {
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.28);
+}
+
 .app-shell {
   min-height: 100vh;
   display: flex;
@@ -462,11 +466,13 @@ body {
 
 .selection-actions {
   display: flex;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
 }
 
 .selection-actions .pill-button {
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .preset-header {


### PR DESCRIPTION
## Summary
- shrink deck selection actions to use the sidebar's small pill styling
- adjust layout and shadow so the controls sit comfortably with other sidebar buttons

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d401e6961483258282ad215e40d398