### PR TITLE
Add essential verb phrases and update decks

### DIFF
--- a/decks/essential-verbs.json
+++ b/decks/essential-verbs.json
@@ -1,807 +1,1927 @@
 {
   "id": "essential-verbs",
   "title": "Essential Verbs",
-  "description": "Core Japanese verbs for everyday communication. Includes 160 card(s).",
+  "description": "Core Japanese verbs for everyday communication with verb class tags. Includes 160 card(s).",
   "cards": [
     {
       "english": "add",
       "romaji": "tasu",
-      "japanese": "足す / たす"
+      "japanese": "足す / たす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "answer",
       "romaji": "kotaeru",
-      "japanese": "答える / こたえる"
+      "japanese": "答える / こたえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "arrive",
       "romaji": "tsuku",
-      "japanese": "着く / つく"
+      "japanese": "着く / つく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "bathe, take a shower",
       "romaji": "abiru",
-      "japanese": "浴びる / あびる"
+      "japanese": "浴びる / あびる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be",
       "romaji": "iru",
-      "japanese": "居る / いる"
+      "japanese": "居る / いる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be able",
       "romaji": "dekiru",
-      "japanese": "出来る / できる"
+      "japanese": "出来る / できる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be born",
       "romaji": "umareru",
-      "japanese": "生まれる / うまれる"
+      "japanese": "生まれる / うまれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be cured, healed",
       "romaji": "naoru",
-      "japanese": "直る / なおる"
+      "japanese": "直る / なおる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be defeated, lose a game",
       "romaji": "makeru",
-      "japanese": "負ける / まける"
+      "japanese": "負ける / まける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be different, wrong",
       "romaji": "chigau",
-      "japanese": "違う / ちがう"
+      "japanese": "違う / ちがう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be enough, suffient",
       "romaji": "tariru",
-      "japanese": "足りる / たりる"
+      "japanese": "足りる / たりる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be found",
       "romaji": "mitsukaru",
-      "japanese": "見つかる / みつかる"
+      "japanese": "見つかる / みつかる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be glad, pleased",
       "romaji": "yorokobu",
-      "japanese": "喜ぶ"
+      "japanese": "喜ぶ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be in trouble",
       "romaji": "komaru",
-      "japanese": "困る / こまる"
+      "japanese": "困る / こまる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be missing, vanish",
       "romaji": "nakunaru",
-      "japanese": "無くなる / なくなる"
+      "japanese": "無くなる / なくなる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "be visible, able to see",
       "romaji": "mieru",
-      "japanese": "見える / みえる"
+      "japanese": "見える / みえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "become",
       "romaji": "naru",
-      "japanese": "なる"
+      "japanese": "なる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "become crowded",
       "romaji": "komu",
-      "japanese": "込む / こむ"
+      "japanese": "込む / こむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "become wet",
       "romaji": "nureru",
-      "japanese": "濡れる / ぬれる"
+      "japanese": "濡れる / ぬれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "begin",
       "romaji": "hajimeru",
-      "japanese": "始める / はじめる"
+      "japanese": "始める / はじめる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "begin",
       "romaji": "hajimaru",
-      "japanese": "始まる / はじまる"
+      "japanese": "始まる / はじまる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "bloom",
       "romaji": "saku",
-      "japanese": "咲く / さく"
+      "japanese": "咲く / さく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "blow, wipe",
       "romaji": "fuku",
-      "japanese": "吹く / ふく"
+      "japanese": "吹く / ふく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "board, ride on",
       "romaji": "noru",
-      "japanese": "乗る / のる"
+      "japanese": "乗る / のる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "borrow, rent",
       "romaji": "kariru",
-      "japanese": "借りる / かりる"
+      "japanese": "借りる / かりる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "build",
       "romaji": "tateru",
-      "japanese": "立てる / たてる"
+      "japanese": "立てる / たてる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "buy",
       "romaji": "kau",
-      "japanese": "買う / かう"
+      "japanese": "買う / かう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "call",
       "romaji": "yobu",
-      "japanese": "呼ぶ / よぶ"
+      "japanese": "呼ぶ / よぶ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "check, investigate",
       "romaji": "shiraberu",
-      "japanese": "調べる / しらべる"
+      "japanese": "調べる / しらべる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "choose, select",
       "romaji": "erabu",
-      "japanese": "選ぶ / えらぶ"
+      "japanese": "選ぶ / えらぶ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "clear up, tidy up",
       "romaji": "hareru",
-      "japanese": "晴れる / はれる"
+      "japanese": "晴れる / はれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "climb",
       "romaji": "noboru",
-      "japanese": "登る / のぼる"
+      "japanese": "登る / のぼる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "close, be closed",
       "romaji": "shimaru",
-      "japanese": "閉まる / しまる"
+      "japanese": "閉まる / しまる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "come",
       "romaji": "kuru",
-      "japanese": "来る / くる"
+      "japanese": "来る / くる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "come/go (humble)",
       "romaji": "mairu",
-      "japanese": "参る / まいる"
+      "japanese": "参る / まいる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "continue, follow",
       "romaji": "tsuzuku",
-      "japanese": "続く / つづく"
+      "japanese": "続く / つづく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "continue, proceed",
       "romaji": "tsuzukeru",
-      "japanese": "続ける / つづける"
+      "japanese": "続ける / つづける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "cross",
       "romaji": "wataru",
-      "japanese": "渡る / わたる"
+      "japanese": "渡る / わたる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "cry",
       "romaji": "naku",
-      "japanese": "泣く / なく"
+      "japanese": "泣く / なく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "cut",
       "romaji": "kiru",
-      "japanese": "切る / きる"
+      "japanese": "切る / きる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "decide, choose",
       "romaji": "kimeru",
-      "japanese": "決める"
+      "japanese": "決める",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "die",
       "romaji": "shinu",
-      "japanese": "死ぬ / しぬ"
+      "japanese": "死ぬ / しぬ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "do, give",
       "romaji": "yaru",
-      "japanese": "やる"
+      "japanese": "やる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "do, make",
       "romaji": "suru",
-      "japanese": "する"
+      "japanese": "する",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "drink",
       "romaji": "nomu",
-      "japanese": "飲む / のむ"
+      "japanese": "飲む / のむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "eat",
       "romaji": "taberu",
-      "japanese": "食べる / たべる"
+      "japanese": "食べる / たべる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "end",
       "romaji": "owaru",
-      "japanese": "終わる / おわる"
+      "japanese": "終わる / おわる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "enjoy, have fun",
       "romaji": "tanoshimu",
-      "japanese": "楽しむ / たのしむ"
+      "japanese": "楽しむ / たのしむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "enter",
       "romaji": "hairu",
-      "japanese": "入る / はいる"
+      "japanese": "入る / はいる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "exchange",
       "romaji": "torikaeru",
-      "japanese": "取り換える / とりかえる"
+      "japanese": "取り換える / とりかえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "extract, take out",
       "romaji": "dasu",
-      "japanese": "出す / だす"
+      "japanese": "出す / だす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "fall down, collapse",
       "romaji": "taoreru",
-      "japanese": "倒れる / たおれる"
+      "japanese": "倒れる / たおれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "fall from the sky",
       "romaji": "furu",
-      "japanese": "降る / ふる"
+      "japanese": "降る / ふる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "fall, drop, hang",
       "romaji": "sagaru",
-      "japanese": "下がる / さがる"
+      "japanese": "下がる / さがる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "find",
       "romaji": "mitsukeru",
-      "japanese": "見つける / みつける"
+      "japanese": "見つける / みつける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "fish",
       "romaji": "tsuru",
-      "japanese": "釣る / つる"
+      "japanese": "釣る / つる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "forget",
       "romaji": "wasureru",
-      "japanese": "忘れる / わすれる"
+      "japanese": "忘れる / わすれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "form a line, equal",
       "romaji": "narabu",
-      "japanese": "並ぶ / ならぶ"
+      "japanese": "並ぶ / ならぶ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "get off, go down",
       "romaji": "oriru",
-      "japanese": "降りる / おりる"
+      "japanese": "降りる / おりる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "get tired",
       "romaji": "tsukareru",
-      "japanese": "疲れる / つかれる"
+      "japanese": "疲れる / つかれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "get up",
       "romaji": "okiru",
-      "japanese": "起きる / おきる"
+      "japanese": "起きる / おきる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "give",
       "romaji": "ageru",
-      "japanese": "あげる"
+      "japanese": "あげる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "give back, return (something to someone)",
       "romaji": "kaesu",
-      "japanese": "返す / かえす"
+      "japanese": "返す / かえす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "go",
       "romaji": "iku",
-      "japanese": "行く / いく"
+      "japanese": "行く / いく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "go forward, advance",
       "romaji": "susumu",
-      "japanese": "進む / すすむ"
+      "japanese": "進む / すすむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "go out",
       "romaji": "deru",
-      "japanese": "出る / でる"
+      "japanese": "出る / でる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "go out, leave home",
       "romaji": "dekakeru",
-      "japanese": "出かける / でかける"
+      "japanese": "出かける / でかける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "go round",
       "romaji": "mawaru",
-      "japanese": "回る / まわる"
+      "japanese": "回る / まわる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "go up, rise",
       "romaji": "agaru",
-      "japanese": "上がる / あがる"
+      "japanese": "上がる / あがる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "greet, meet, welcome",
       "romaji": "mukaeru",
-      "japanese": "迎える / むかえる"
+      "japanese": "迎える / むかえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "hand over",
       "romaji": "watasu",
-      "japanese": "渡す / わたす"
+      "japanese": "渡す / わたす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "hang, sit, telephone, risk",
       "romaji": "kakeru",
-      "japanese": "掛ける / かける"
+      "japanese": "掛ける / かける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "have, exist",
       "romaji": "aru",
-      "japanese": "有る / ある"
+      "japanese": "有る / ある",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "have, hold, own",
       "romaji": "motsu",
-      "japanese": "持つ / もつ"
+      "japanese": "持つ / もつ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "help",
       "romaji": "tasukeru",
-      "japanese": "助ける / たすける"
+      "japanese": "助ける / たすける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "inhale, sip, smoke",
       "romaji": "suu",
-      "japanese": "吸う / すう"
+      "japanese": "吸う / すう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "jump, fly",
       "romaji": "tobu",
-      "japanese": "飛ぶ / とぶ"
+      "japanese": "飛ぶ / とぶ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "know",
       "romaji": "shiru",
-      "japanese": "知る / しる"
+      "japanese": "知る / しる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "laugh",
       "romaji": "warau",
-      "japanese": "笑う / わらう"
+      "japanese": "笑う / わらう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "lead",
       "romaji": "tsureru",
-      "japanese": "連れる / つれる"
+      "japanese": "連れる / つれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "learn",
       "romaji": "narau",
-      "japanese": "習う / ならう"
+      "japanese": "習う / ならう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "lend",
       "romaji": "kasu",
-      "japanese": "貸す / かす"
+      "japanese": "貸す / かす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "line up, list, arrange in order",
       "romaji": "naraberu",
-      "japanese": "並べる / ならべる"
+      "japanese": "並べる / ならべる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "listen",
       "romaji": "kiku",
-      "japanese": "聞く / きく"
+      "japanese": "聞く / きく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "live, reside",
       "romaji": "sumu",
-      "japanese": "住む / すむ"
+      "japanese": "住む / すむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "look",
       "romaji": "miru",
-      "japanese": "見る / みる"
+      "japanese": "見る / みる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "lower, hang",
       "romaji": "sageru",
-      "japanese": "下げる / さげる"
+      "japanese": "下げる / さげる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "make a mistake",
       "romaji": "machigaeru",
-      "japanese": "間違える / まちがえる"
+      "japanese": "間違える / まちがえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "make a noise, be rowdy",
       "romaji": "sawagu",
-      "japanese": "騒ぐ / さわぐ"
+      "japanese": "騒ぐ / さわぐ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "make, build, create",
       "romaji": "tsukuru",
-      "japanese": "作る / つくる"
+      "japanese": "作る / つくる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "meet",
       "romaji": "au",
-      "japanese": "会う / あう"
+      "japanese": "会う / あう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "need",
       "romaji": "iru",
-      "japanese": "要る / いる"
+      "japanese": "要る / いる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "notify",
       "romaji": "shiraseru",
-      "japanese": "知らせる / しらせる"
+      "japanese": "知らせる / しらせる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "open",
       "romaji": "akeru",
-      "japanese": "開ける / あける"
+      "japanese": "開ける / あける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "open, become vacant",
       "romaji": "aku",
-      "japanese": "開く / あく"
+      "japanese": "開く / あく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "paint",
       "romaji": "nuru",
-      "japanese": "塗る / ぬる"
+      "japanese": "塗る / ぬる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "part, separate from, be divided, divorced",
       "romaji": "wakareru",
-      "japanese": "別れる / わかれる"
+      "japanese": "別れる / わかれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "pass, exceed",
       "romaji": "sugiru",
-      "japanese": "過ぎる / すぎる"
+      "japanese": "過ぎる / すぎる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "pay",
       "romaji": "harau",
-      "japanese": "払う / はらう"
+      "japanese": "払う / はらう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "play",
       "romaji": "asobu",
-      "japanese": "遊ぶ / あそぶ"
+      "japanese": "遊ぶ / あそぶ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "point out, sting, stab",
       "romaji": "sasu",
-      "japanese": "刺す / さす"
+      "japanese": "刺す / さす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "polish",
       "romaji": "migaku",
-      "japanese": "磨く / みがく"
+      "japanese": "磨く / みがく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "praise",
       "romaji": "homeru",
-      "japanese": "褒める / ほめる"
+      "japanese": "褒める / ほめる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "pull",
       "romaji": "hiku",
-      "japanese": "引く / ひく"
+      "japanese": "引く / ひく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "push, press",
       "romaji": "osu",
-      "japanese": "押す / おす"
+      "japanese": "押す / おす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "put in, let in",
       "romaji": "ireru",
-      "japanese": "入れる / いれる"
+      "japanese": "入れる / いれる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "put on, wear (on feet or legs - trousers/shoes etc)",
       "romaji": "haku",
-      "japanese": "履く / はく"
+      "japanese": "履く / はく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "put, place",
       "romaji": "oku",
-      "japanese": "置く / おく"
+      "japanese": "置く / おく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "read",
       "romaji": "yomu",
-      "japanese": "読む / よむ"
+      "japanese": "読む / よむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "receive, get",
       "romaji": "morau",
-      "japanese": "貰う / もらう"
+      "japanese": "貰う / もらう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "remember, learn",
       "romaji": "oboeru",
-      "japanese": "覚える / おぼえる"
+      "japanese": "覚える / おぼえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "repair, cure",
       "romaji": "naosu",
-      "japanese": "直す / なおす"
+      "japanese": "直す / なおす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "request, order, ask favour",
       "romaji": "tanomu",
-      "japanese": "頼む / たのむ"
+      "japanese": "頼む / たのむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "rest, sleep",
       "romaji": "yasumu",
-      "japanese": "休む / やすむ"
+      "japanese": "休む / やすむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "return, go home",
       "romaji": "kaeru",
-      "japanese": "帰る / かえる"
+      "japanese": "帰る / かえる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "run",
       "romaji": "hashiru",
-      "japanese": "走る / はしる"
+      "japanese": "走る / はしる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "run, canter, gallop",
       "romaji": "kakeru",
-      "japanese": "かける"
+      "japanese": "かける",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "say",
       "romaji": "iu",
-      "japanese": "言う / いう"
+      "japanese": "言う / いう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "scold, tell off",
       "romaji": "shikaru",
-      "japanese": "叱る / しかる"
+      "japanese": "叱る / しかる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "search for",
       "romaji": "sagasu",
-      "japanese": "探す / さがす"
+      "japanese": "探す / さがす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "sell",
       "romaji": "uru",
-      "japanese": "売る / うる"
+      "japanese": "売る / うる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "send, see off",
       "romaji": "okuru",
-      "japanese": "送る / おくる"
+      "japanese": "送る / おくる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "show",
       "romaji": "miseru",
-      "japanese": "見せる / みせる"
+      "japanese": "見せる / みせる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "shut",
       "romaji": "shimeru",
-      "japanese": "閉める / しめる"
+      "japanese": "閉める / しめる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "sing",
       "romaji": "utau",
-      "japanese": "歌う / うたう"
+      "japanese": "歌う / うたう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "sit",
       "romaji": "suwaru",
-      "japanese": "座る / すわる"
+      "japanese": "座る / すわる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "sleep, go to bed",
       "romaji": "neru",
-      "japanese": "寝る / ねる"
+      "japanese": "寝る / ねる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "slip",
       "romaji": "suberu",
-      "japanese": "滑る / すべる"
+      "japanese": "滑る / すべる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "speak",
       "romaji": "hanasu",
-      "japanese": "話す / はなす"
+      "japanese": "話す / はなす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "stand up",
       "romaji": "tatsu",
-      "japanese": "立つ"
+      "japanese": "立つ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "steal",
       "romaji": "nusumu",
-      "japanese": "盗む / ぬすむ"
+      "japanese": "盗む / ぬすむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "stick, put something on",
       "romaji": "haru",
-      "japanese": "張る / はる"
+      "japanese": "張る / はる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "stop",
       "romaji": "tomaru",
-      "japanese": "止まる / とまる"
+      "japanese": "止まる / とまる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "stop, fasten",
       "romaji": "tomeru",
-      "japanese": "止める / とめる"
+      "japanese": "止める / とめる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "stop, give up, resign",
       "romaji": "yameru",
-      "japanese": "止める / やめる"
+      "japanese": "止める / やめる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "swim",
       "romaji": "oyogu",
-      "japanese": "泳ぐ / およぐ"
+      "japanese": "泳ぐ / およぐ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "take off, remove (shoes, clothes)",
       "romaji": "nugu",
-      "japanese": "脱ぐ / ぬぐ"
+      "japanese": "脱ぐ / ぬぐ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "take, begin, be hanging",
       "romaji": "kakaru",
-      "japanese": "掛かる / かかる"
+      "japanese": "掛かる / かかる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "take, steal",
       "romaji": "toru",
-      "japanese": "取る / とる"
+      "japanese": "取る / とる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "teach, show",
       "romaji": "oshieru",
-      "japanese": "教える / おしえる"
+      "japanese": "教える / おしえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "think",
       "romaji": "omou",
-      "japanese": "思う / おもう"
+      "japanese": "思う / おもう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "throw away",
       "romaji": "nageru",
-      "japanese": "投げる / なげる"
+      "japanese": "投げる / なげる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "throw away",
       "romaji": "suteru",
-      "japanese": "捨てる / すてる"
+      "japanese": "捨てる / すてる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "to rear, to bring up",
       "romaji": "sodateru",
-      "japanese": "育てる / そだてる"
+      "japanese": "育てる / そだてる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "touch or feel (with hands)",
       "romaji": "sawaru",
-      "japanese": "触る / さわる"
+      "japanese": "触る / さわる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "turn off, erase",
       "romaji": "kesu",
-      "japanese": "消す / けす"
+      "japanese": "消す / けす",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "turn on, light",
       "romaji": "tsukeru",
-      "japanese": "点ける / つける"
+      "japanese": "点ける / つける",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "turn, bend",
       "romaji": "magaru",
-      "japanese": "曲がる / まがる"
+      "japanese": "曲がる / まがる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "understand",
       "romaji": "wakaru",
-      "japanese": "分かる / わかる"
+      "japanese": "分かる / わかる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "use, operate",
       "romaji": "tsukau",
-      "japanese": "使う / つかう"
+      "japanese": "使う / つかう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "vanish, go out, be extinguished",
       "romaji": "kieru",
-      "japanese": "消える / きえる"
+      "japanese": "消える / きえる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "wait",
       "romaji": "matsu",
-      "japanese": "待つ / まつ"
+      "japanese": "待つ / まつ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "walk",
       "romaji": "aruku",
-      "japanese": "歩く / あるく"
+      "japanese": "歩く / あるく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "wash",
       "romaji": "arau",
-      "japanese": "洗う / あらう"
+      "japanese": "洗う / あらう",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "wear",
       "romaji": "kiru",
-      "japanese": "着る / きる"
+      "japanese": "着る / きる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "wear (on your head), put on",
       "romaji": "kaburu",
-      "japanese": "被る / かぶる"
+      "japanese": "被る / かぶる",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "work",
       "romaji": "hataraku",
-      "japanese": "働く / はたらく"
+      "japanese": "働く / はたらく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "work for",
       "romaji": "tsutomeru",
-      "japanese": "勤める / つとめる"
+      "japanese": "勤める / つとめる",
+      "class": 2,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "wrap",
       "romaji": "tsutsumu",
-      "japanese": "包む / つつむ"
+      "japanese": "包む / つつむ",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     },
     {
       "english": "write",
       "romaji": "kaku",
-      "japanese": "書く / かく"
+      "japanese": "書く / かく",
+      "class": 1,
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
     }
   ]
 }

--- a/decks/manifest.json
+++ b/decks/manifest.json
@@ -2,13 +2,13 @@
   {
     "id": "essential-verbs",
     "title": "Essential Verbs",
-    "description": "Core Japanese verbs for everyday communication. Includes 160 card(s).",
+    "description": "Core Japanese verbs for everyday communication with verb class tags. Includes 160 card(s).",
     "file": "essential-verbs.json"
   },
   {
     "id": "travel-phrases",
     "title": "Travel Phrase Collection",
-    "description": "Comprehensive travel phrases with 1137 card(s) and 315 tags for filtering.",
+    "description": "Comprehensive travel phrases with 1294 card(s) and 318 tags for filtering.",
     "file": "travel-phrases.json"
   }
 ]

--- a/decks/travel-phrases.json
+++ b/decks/travel-phrases.json
@@ -1,8 +1,1749 @@
 {
   "id": "travel-phrases",
   "title": "Travel Phrase Collection",
-  "description": "Comprehensive travel phrases with 1137 card(s) and 315 tags for filtering.",
+  "description": "Comprehensive travel phrases with 1294 card(s) and 318 tags for filtering.",
   "cards": [
+    {
+      "english": "add",
+      "romaji": "tasu",
+      "japanese": "足す / たす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "answer",
+      "romaji": "kotaeru",
+      "japanese": "答える / こたえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "arrive",
+      "romaji": "tsuku",
+      "japanese": "着く / つく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "bathe, take a shower",
+      "romaji": "abiru",
+      "japanese": "浴びる / あびる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be",
+      "romaji": "iru",
+      "japanese": "居る / いる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be able",
+      "romaji": "dekiru",
+      "japanese": "出来る / できる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be born",
+      "romaji": "umareru",
+      "japanese": "生まれる / うまれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be cured, healed",
+      "romaji": "naoru",
+      "japanese": "直る / なおる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be defeated, lose a game",
+      "romaji": "makeru",
+      "japanese": "負ける / まける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be different, wrong",
+      "romaji": "chigau",
+      "japanese": "違う / ちがう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be enough, suffient",
+      "romaji": "tariru",
+      "japanese": "足りる / たりる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be found",
+      "romaji": "mitsukaru",
+      "japanese": "見つかる / みつかる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be glad, pleased",
+      "romaji": "yorokobu",
+      "japanese": "喜ぶ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be in trouble",
+      "romaji": "komaru",
+      "japanese": "困る / こまる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be missing, vanish",
+      "romaji": "nakunaru",
+      "japanese": "無くなる / なくなる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "be visible, able to see",
+      "romaji": "mieru",
+      "japanese": "見える / みえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "become",
+      "romaji": "naru",
+      "japanese": "なる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "become crowded",
+      "romaji": "komu",
+      "japanese": "込む / こむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "become wet",
+      "romaji": "nureru",
+      "japanese": "濡れる / ぬれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "begin",
+      "romaji": "hajimeru",
+      "japanese": "始める / はじめる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "bloom",
+      "romaji": "saku",
+      "japanese": "咲く / さく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "blow, wipe",
+      "romaji": "fuku",
+      "japanese": "吹く / ふく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "board, ride on",
+      "romaji": "noru",
+      "japanese": "乗る / のる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "borrow, rent",
+      "romaji": "kariru",
+      "japanese": "借りる / かりる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "build",
+      "romaji": "tateru",
+      "japanese": "立てる / たてる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "buy",
+      "romaji": "kau",
+      "japanese": "買う / かう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "call",
+      "romaji": "yobu",
+      "japanese": "呼ぶ / よぶ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "check, investigate",
+      "romaji": "shiraberu",
+      "japanese": "調べる / しらべる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "choose, select",
+      "romaji": "erabu",
+      "japanese": "選ぶ / えらぶ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "clear up, tidy up",
+      "romaji": "hareru",
+      "japanese": "晴れる / はれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "climb",
+      "romaji": "noboru",
+      "japanese": "登る / のぼる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "close, be closed",
+      "romaji": "shimaru",
+      "japanese": "閉まる / しまる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "come",
+      "romaji": "kuru",
+      "japanese": "来る / くる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "come/go (humble)",
+      "romaji": "mairu",
+      "japanese": "参る / まいる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "continue, follow",
+      "romaji": "tsuzuku",
+      "japanese": "続く / つづく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "continue, proceed",
+      "romaji": "tsuzukeru",
+      "japanese": "続ける / つづける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "cross",
+      "romaji": "wataru",
+      "japanese": "渡る / わたる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "cry",
+      "romaji": "naku",
+      "japanese": "泣く / なく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "cut",
+      "romaji": "kiru",
+      "japanese": "切る / きる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "decide, choose",
+      "romaji": "kimeru",
+      "japanese": "決める",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "die",
+      "romaji": "shinu",
+      "japanese": "死ぬ / しぬ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "do, give",
+      "romaji": "yaru",
+      "japanese": "やる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "do, make",
+      "romaji": "suru",
+      "japanese": "する",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "drink",
+      "romaji": "nomu",
+      "japanese": "飲む / のむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "eat",
+      "romaji": "taberu",
+      "japanese": "食べる / たべる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "end",
+      "romaji": "owaru",
+      "japanese": "終わる / おわる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "enjoy, have fun",
+      "romaji": "tanoshimu",
+      "japanese": "楽しむ / たのしむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "enter",
+      "romaji": "hairu",
+      "japanese": "入る / はいる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "exchange",
+      "romaji": "torikaeru",
+      "japanese": "取り換える / とりかえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "extract, take out",
+      "romaji": "dasu",
+      "japanese": "出す / だす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "fall down, collapse",
+      "romaji": "taoreru",
+      "japanese": "倒れる / たおれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "fall from the sky",
+      "romaji": "furu",
+      "japanese": "降る / ふる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "fall, drop, hang",
+      "romaji": "sagaru",
+      "japanese": "下がる / さがる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "find",
+      "romaji": "mitsukeru",
+      "japanese": "見つける / みつける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "fish",
+      "romaji": "tsuru",
+      "japanese": "釣る / つる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)",
+        "Animals",
+        "Food"
+      ],
+      "usefulness": 9
+    },
+    {
+      "english": "forget",
+      "romaji": "wasureru",
+      "japanese": "忘れる / わすれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "form a line, equal",
+      "romaji": "narabu",
+      "japanese": "並ぶ / ならぶ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "get off, go down",
+      "romaji": "oriru",
+      "japanese": "降りる / おりる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "get tired",
+      "romaji": "tsukareru",
+      "japanese": "疲れる / つかれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "get up",
+      "romaji": "okiru",
+      "japanese": "起きる / おきる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "give",
+      "romaji": "ageru",
+      "japanese": "あげる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "give back, return (something to someone)",
+      "romaji": "kaesu",
+      "japanese": "返す / かえす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "go",
+      "romaji": "iku",
+      "japanese": "行く / いく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "go forward, advance",
+      "romaji": "susumu",
+      "japanese": "進む / すすむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "go out",
+      "romaji": "deru",
+      "japanese": "出る / でる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "go out, leave home",
+      "romaji": "dekakeru",
+      "japanese": "出かける / でかける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "go round",
+      "romaji": "mawaru",
+      "japanese": "回る / まわる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "go up, rise",
+      "romaji": "agaru",
+      "japanese": "上がる / あがる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "greet, meet, welcome",
+      "romaji": "mukaeru",
+      "japanese": "迎える / むかえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "hand over",
+      "romaji": "watasu",
+      "japanese": "渡す / わたす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "hang, sit, telephone, risk",
+      "romaji": "kakeru",
+      "japanese": "掛ける / かける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "have, exist",
+      "romaji": "aru",
+      "japanese": "有る / ある",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "have, hold, own",
+      "romaji": "motsu",
+      "japanese": "持つ / もつ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "help",
+      "romaji": "tasukeru",
+      "japanese": "助ける / たすける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "inhale, sip, smoke",
+      "romaji": "suu",
+      "japanese": "吸う / すう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "jump, fly",
+      "romaji": "tobu",
+      "japanese": "飛ぶ / とぶ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "know",
+      "romaji": "shiru",
+      "japanese": "知る / しる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "laugh",
+      "romaji": "warau",
+      "japanese": "笑う / わらう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "lead",
+      "romaji": "tsureru",
+      "japanese": "連れる / つれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "learn",
+      "romaji": "narau",
+      "japanese": "習う / ならう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "lend",
+      "romaji": "kasu",
+      "japanese": "貸す / かす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "line up, list, arrange in order",
+      "romaji": "naraberu",
+      "japanese": "並べる / ならべる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "listen",
+      "romaji": "kiku",
+      "japanese": "聞く / きく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "live, reside",
+      "romaji": "sumu",
+      "japanese": "住む / すむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "look",
+      "romaji": "miru",
+      "japanese": "見る / みる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "lower, hang",
+      "romaji": "sageru",
+      "japanese": "下げる / さげる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "make a mistake",
+      "romaji": "machigaeru",
+      "japanese": "間違える / まちがえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "make a noise, be rowdy",
+      "romaji": "sawagu",
+      "japanese": "騒ぐ / さわぐ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "make, build, create",
+      "romaji": "tsukuru",
+      "japanese": "作る / つくる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "meet",
+      "romaji": "au",
+      "japanese": "会う / あう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "need",
+      "romaji": "iru",
+      "japanese": "要る / いる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "notify",
+      "romaji": "shiraseru",
+      "japanese": "知らせる / しらせる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "open",
+      "romaji": "akeru",
+      "japanese": "開ける / あける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "open, become vacant",
+      "romaji": "aku",
+      "japanese": "開く / あく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "paint",
+      "romaji": "nuru",
+      "japanese": "塗る / ぬる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "part, separate from, be divided, divorced",
+      "romaji": "wakareru",
+      "japanese": "別れる / わかれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "pass, exceed",
+      "romaji": "sugiru",
+      "japanese": "過ぎる / すぎる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "pay",
+      "romaji": "harau",
+      "japanese": "払う / はらう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "play",
+      "romaji": "asobu",
+      "japanese": "遊ぶ / あそぶ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "point out, sting, stab",
+      "romaji": "sasu",
+      "japanese": "刺す / さす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "polish",
+      "romaji": "migaku",
+      "japanese": "磨く / みがく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "praise",
+      "romaji": "homeru",
+      "japanese": "褒める / ほめる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "pull",
+      "romaji": "hiku",
+      "japanese": "引く / ひく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "push, press",
+      "romaji": "osu",
+      "japanese": "押す / おす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "put in, let in",
+      "romaji": "ireru",
+      "japanese": "入れる / いれる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "put on, wear (on feet or legs - trousers/shoes etc)",
+      "romaji": "haku",
+      "japanese": "履く / はく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "put, place",
+      "romaji": "oku",
+      "japanese": "置く / おく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "read",
+      "romaji": "yomu",
+      "japanese": "読む / よむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "receive, get",
+      "romaji": "morau",
+      "japanese": "貰う / もらう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "remember, learn",
+      "romaji": "oboeru",
+      "japanese": "覚える / おぼえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "repair, cure",
+      "romaji": "naosu",
+      "japanese": "直す / なおす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "request, order, ask favour",
+      "romaji": "tanomu",
+      "japanese": "頼む / たのむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "rest, sleep",
+      "romaji": "yasumu",
+      "japanese": "休む / やすむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "return, go home",
+      "romaji": "kaeru",
+      "japanese": "帰る / かえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "run",
+      "romaji": "hashiru",
+      "japanese": "走る / はしる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "run, canter, gallop",
+      "romaji": "kakeru",
+      "japanese": "かける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "say",
+      "romaji": "iu",
+      "japanese": "言う / いう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "scold, tell off",
+      "romaji": "shikaru",
+      "japanese": "叱る / しかる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "search for",
+      "romaji": "sagasu",
+      "japanese": "探す / さがす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "sell",
+      "romaji": "uru",
+      "japanese": "売る / うる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "send, see off",
+      "romaji": "okuru",
+      "japanese": "送る / おくる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "show",
+      "romaji": "miseru",
+      "japanese": "見せる / みせる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "shut",
+      "romaji": "shimeru",
+      "japanese": "閉める / しめる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "sing",
+      "romaji": "utau",
+      "japanese": "歌う / うたう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "sit",
+      "romaji": "suwaru",
+      "japanese": "座る / すわる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "sleep, go to bed",
+      "romaji": "neru",
+      "japanese": "寝る / ねる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "slip",
+      "romaji": "suberu",
+      "japanese": "滑る / すべる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "speak",
+      "romaji": "hanasu",
+      "japanese": "話す / はなす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "stand up",
+      "romaji": "tatsu",
+      "japanese": "立つ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "steal",
+      "romaji": "nusumu",
+      "japanese": "盗む / ぬすむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "stick, put something on",
+      "romaji": "haru",
+      "japanese": "張る / はる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "stop",
+      "romaji": "tomaru",
+      "japanese": "止まる / とまる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "stop, fasten",
+      "romaji": "tomeru",
+      "japanese": "止める / とめる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "stop, give up, resign",
+      "romaji": "yameru",
+      "japanese": "止める / やめる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "swim",
+      "romaji": "oyogu",
+      "japanese": "泳ぐ / およぐ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "take off, remove (shoes, clothes)",
+      "romaji": "nugu",
+      "japanese": "脱ぐ / ぬぐ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "take, begin, be hanging",
+      "romaji": "kakaru",
+      "japanese": "掛かる / かかる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "take, steal",
+      "romaji": "toru",
+      "japanese": "取る / とる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "teach, show",
+      "romaji": "oshieru",
+      "japanese": "教える / おしえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "think",
+      "romaji": "omou",
+      "japanese": "思う / おもう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "throw away",
+      "romaji": "nageru",
+      "japanese": "投げる / なげる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "to rear, to bring up",
+      "romaji": "sodateru",
+      "japanese": "育てる / そだてる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "touch or feel (with hands)",
+      "romaji": "sawaru",
+      "japanese": "触る / さわる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "turn off, erase",
+      "romaji": "kesu",
+      "japanese": "消す / けす",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "turn on, light",
+      "romaji": "tsukeru",
+      "japanese": "点ける / つける",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "turn, bend",
+      "romaji": "magaru",
+      "japanese": "曲がる / まがる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "understand",
+      "romaji": "wakaru",
+      "japanese": "分かる / わかる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "use, operate",
+      "romaji": "tsukau",
+      "japanese": "使う / つかう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "vanish, go out, be extinguished",
+      "romaji": "kieru",
+      "japanese": "消える / きえる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "wait",
+      "romaji": "matsu",
+      "japanese": "待つ / まつ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "walk",
+      "romaji": "aruku",
+      "japanese": "歩く / あるく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "wash",
+      "romaji": "arau",
+      "japanese": "洗う / あらう",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "wear",
+      "romaji": "kiru",
+      "japanese": "着る / きる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "wear (on your head), put on",
+      "romaji": "kaburu",
+      "japanese": "被る / かぶる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "work",
+      "romaji": "hataraku",
+      "japanese": "働く / はたらく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "work for",
+      "romaji": "tsutomeru",
+      "japanese": "勤める / つとめる",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 2 (Ichidan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "wrap",
+      "romaji": "tsutsumu",
+      "japanese": "包む / つつむ",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
+    {
+      "english": "write",
+      "romaji": "kaku",
+      "japanese": "書く / かく",
+      "tags": [
+        "Vocabulary",
+        "Essential Verbs",
+        "Verb Class 1 (Godan)"
+      ],
+      "usefulness": 6
+    },
     {
       "english": "No, I can’t eat it.",
       "romaji": "Iie, taberaremasen.",
@@ -9098,17 +10839,6 @@
         "Vocabulary"
       ],
       "usefulness": 5
-    },
-    {
-      "english": "Fish",
-      "romaji": "sakana",
-      "japanese": "魚",
-      "tags": [
-        "Animals",
-        "Vocabulary",
-        "Food"
-      ],
-      "usefulness": 9
     },
     {
       "english": "Grandfather",

--- a/phrases/essential-verbs.tsv
+++ b/phrases/essential-verbs.tsv
@@ -1,0 +1,161 @@
+Tags	Traveler Usefulness (1-10)	English	Romanji	Japanese
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	add	tasu	足す / たす
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	answer	kotaeru	答える / こたえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	arrive	tsuku	着く / つく
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	bathe, take a shower	abiru	浴びる / あびる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	be	iru	居る / いる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	be able	dekiru	出来る / できる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	be born	umareru	生まれる / うまれる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	be cured, healed	naoru	直る / なおる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	be defeated, lose a game	makeru	負ける / まける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	be different, wrong	chigau	違う / ちがう
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	be enough, suffient	tariru	足りる / たりる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	be found	mitsukaru	見つかる / みつかる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	be glad, pleased	yorokobu	喜ぶ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	be in trouble	komaru	困る / こまる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	be missing, vanish	nakunaru	無くなる / なくなる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	be visible, able to see	mieru	見える / みえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	become	naru	なる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	become crowded	komu	込む / こむ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	become wet	nureru	濡れる / ぬれる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	begin	hajimeru	始める / はじめる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	begin	hajimaru	始まる / はじまる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	bloom	saku	咲く / さく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	blow, wipe	fuku	吹く / ふく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	board, ride on	noru	乗る / のる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	borrow, rent	kariru	借りる / かりる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	build	tateru	立てる / たてる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	buy	kau	買う / かう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	call	yobu	呼ぶ / よぶ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	check, investigate	shiraberu	調べる / しらべる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	choose, select	erabu	選ぶ / えらぶ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	clear up, tidy up	hareru	晴れる / はれる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	climb	noboru	登る / のぼる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	close, be closed	shimaru	閉まる / しまる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	come	kuru	来る / くる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	come/go (humble)	mairu	参る / まいる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	continue, follow	tsuzuku	続く / つづく
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	continue, proceed	tsuzukeru	続ける / つづける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	cross	wataru	渡る / わたる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	cry	naku	泣く / なく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	cut	kiru	切る / きる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	decide, choose	kimeru	決める
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	die	shinu	死ぬ / しぬ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	do, give	yaru	やる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	do, make	suru	する
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	drink	nomu	飲む / のむ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	eat	taberu	食べる / たべる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	end	owaru	終わる / おわる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	enjoy, have fun	tanoshimu	楽しむ / たのしむ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	enter	hairu	入る / はいる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	exchange	torikaeru	取り換える / とりかえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	extract, take out	dasu	出す / だす
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	fall down, collapse	taoreru	倒れる / たおれる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	fall from the sky	furu	降る / ふる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	fall, drop, hang	sagaru	下がる / さがる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	find	mitsukeru	見つける / みつける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	fish	tsuru	釣る / つる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	forget	wasureru	忘れる / わすれる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	form a line, equal	narabu	並ぶ / ならぶ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	get off, go down	oriru	降りる / おりる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	get tired	tsukareru	疲れる / つかれる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	get up	okiru	起きる / おきる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	give	ageru	あげる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	give back, return (something to someone)	kaesu	返す / かえす
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	go	iku	行く / いく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	go forward, advance	susumu	進む / すすむ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	go out	deru	出る / でる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	go out, leave home	dekakeru	出かける / でかける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	go round	mawaru	回る / まわる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	go up, rise	agaru	上がる / あがる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	greet, meet, welcome	mukaeru	迎える / むかえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	hand over	watasu	渡す / わたす
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	hang, sit, telephone, risk	kakeru	掛ける / かける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	have, exist	aru	有る / ある
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	have, hold, own	motsu	持つ / もつ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	help	tasukeru	助ける / たすける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	inhale, sip, smoke	suu	吸う / すう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	jump, fly	tobu	飛ぶ / とぶ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	know	shiru	知る / しる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	laugh	warau	笑う / わらう
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	lead	tsureru	連れる / つれる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	learn	narau	習う / ならう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	lend	kasu	貸す / かす
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	line up, list, arrange in order	naraberu	並べる / ならべる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	listen	kiku	聞く / きく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	live, reside	sumu	住む / すむ
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	look	miru	見る / みる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	lower, hang	sageru	下げる / さげる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	make a mistake	machigaeru	間違える / まちがえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	make a noise, be rowdy	sawagu	騒ぐ / さわぐ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	make, build, create	tsukuru	作る / つくる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	meet	au	会う / あう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	need	iru	要る / いる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	notify	shiraseru	知らせる / しらせる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	open	akeru	開ける / あける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	open, become vacant	aku	開く / あく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	paint	nuru	塗る / ぬる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	part, separate from, be divided, divorced	wakareru	別れる / わかれる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	pass, exceed	sugiru	過ぎる / すぎる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	pay	harau	払う / はらう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	play	asobu	遊ぶ / あそぶ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	point out, sting, stab	sasu	刺す / さす
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	polish	migaku	磨く / みがく
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	praise	homeru	褒める / ほめる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	pull	hiku	引く / ひく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	push, press	osu	押す / おす
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	put in, let in	ireru	入れる / いれる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	put on, wear (on feet or legs - trousers/shoes etc)	haku	履く / はく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	put, place	oku	置く / おく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	read	yomu	読む / よむ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	receive, get	morau	貰う / もらう
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	remember, learn	oboeru	覚える / おぼえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	repair, cure	naosu	直す / なおす
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	request, order, ask favour	tanomu	頼む / たのむ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	rest, sleep	yasumu	休む / やすむ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	return, go home	kaeru	帰る / かえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	run	hashiru	走る / はしる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	run, canter, gallop	kakeru	かける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	say	iu	言う / いう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	scold, tell off	shikaru	叱る / しかる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	search for	sagasu	探す / さがす
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	sell	uru	売る / うる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	send, see off	okuru	送る / おくる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	show	miseru	見せる / みせる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	shut	shimeru	閉める / しめる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	sing	utau	歌う / うたう
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	sit	suwaru	座る / すわる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	sleep, go to bed	neru	寝る / ねる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	slip	suberu	滑る / すべる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	speak	hanasu	話す / はなす
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	stand up	tatsu	立つ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	steal	nusumu	盗む / ぬすむ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	stick, put something on	haru	張る / はる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	stop	tomaru	止まる / とまる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	stop, fasten	tomeru	止める / とめる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	stop, give up, resign	yameru	止める / やめる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	swim	oyogu	泳ぐ / およぐ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	take off, remove (shoes, clothes)	nugu	脱ぐ / ぬぐ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	take, begin, be hanging	kakaru	掛かる / かかる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	take, steal	toru	取る / とる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	teach, show	oshieru	教える / おしえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	think	omou	思う / おもう
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	throw away	nageru	投げる / なげる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	throw away	suteru	捨てる / すてる
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	to rear, to bring up	sodateru	育てる / そだてる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	touch or feel (with hands)	sawaru	触る / さわる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	turn off, erase	kesu	消す / けす
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	turn on, light	tsukeru	点ける / つける
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	turn, bend	magaru	曲がる / まがる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	understand	wakaru	分かる / わかる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	use, operate	tsukau	使う / つかう
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	vanish, go out, be extinguished	kieru	消える / きえる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	wait	matsu	待つ / まつ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	walk	aruku	歩く / あるく
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	wash	arau	洗う / あらう
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	wear	kiru	着る / きる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	wear (on your head), put on	kaburu	被る / かぶる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	work	hataraku	働く / はたらく
+Vocabulary; Essential Verbs; Verb Class 2 (Ichidan)	6	work for	tsutomeru	勤める / つとめる
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	wrap	tsutsumu	包む / つつむ
+Vocabulary; Essential Verbs; Verb Class 1 (Godan)	6	write	kaku	書く / かく


### PR DESCRIPTION
## Summary
- add a dedicated essential-verbs phrase list with class tags and usefulness metadata
- enrich the essential verbs deck with verb class, tags, and usefulness fields
- regenerate the travel phrase deck and manifest descriptions to include the new verb coverage

## Testing
- python generate_decks.py

------
https://chatgpt.com/codex/tasks/task_e_68d44bf57058832584d339affbd167fb