### PR TITLE
Add spaced repetition review options and deck removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,26 @@
             <button id="prev-card" type="button" class="pill-button ghost" disabled>Previous</button>
             <button id="flip-card" type="button" class="pill-button primary" disabled>Flip Card</button>
             <button id="next-card" type="button" class="pill-button ghost" disabled>Next</button>
+            <button id="remove-card" type="button" class="pill-button outline" disabled>Remove from deck</button>
           </div>
-          <div class="card-hotkeys">Tip: Use ← Back • Space Flip • → Next.</div>
+          <div class="card-feedback" id="card-feedback">
+            <p class="card-feedback-label">How well did you recall it?</p>
+            <div class="card-feedback-buttons">
+              <button id="grade-again" type="button" class="pill-button ghost small" disabled aria-disabled="true">
+                Again
+              </button>
+              <button id="grade-hard" type="button" class="pill-button ghost small" disabled aria-disabled="true">
+                Hard
+              </button>
+              <button id="grade-good" type="button" class="pill-button primary small" disabled aria-disabled="true">
+                Good
+              </button>
+              <button id="grade-easy" type="button" class="pill-button outline small" disabled aria-disabled="true">
+                Easy
+              </button>
+            </div>
+          </div>
+          <div class="card-hotkeys">Tip: ← Back • Space Flip • → Good • 1/2/3/4 = Again/Hard/Good/Easy.</div>
         </section>
       </main>
     </div>

--- a/site.css
+++ b/site.css
@@ -831,15 +831,49 @@ body {
   display: flex;
   gap: 16px;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .card-actions .pill-button {
   padding: 12px 26px;
 }
 
+.card-feedback {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+}
+
+.card-feedback.is-active {
+  opacity: 1;
+}
+
+.card-feedback-label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.card-feedback-buttons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.card-feedback-buttons .pill-button {
+  min-width: 96px;
+}
+
 .card-hotkeys {
   font-size: 0.9rem;
   color: var(--text-muted);
+  text-align: center;
 }
 
 .snackbar {


### PR DESCRIPTION
## Summary
- introduce queue-based spaced repetition with grading controls and keyboard shortcuts for study sessions
- add the ability to remove the current card from a loaded custom deck and persist the change
- update the study card layout with new feedback buttons, removal control, and supporting styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dafdc3d21083259a8850e05eba9253