### PR TITLE
Fix romaji and Japanese voice playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,14 +30,28 @@
           <div class="card-face front" id="cardFront">
             <div class="card-label">Prompt</div>
             <div class="card-content english"></div>
-            <button class="speak" data-target="english" title="Hear this in English">🔊</button>
           </div>
           <div class="card-face back" id="cardBack">
             <div class="card-label">Answer</div>
-            <div class="card-content romaji"></div>
-            <div class="card-content japanese"></div>
+            <div class="card-pronunciation">
+              <div class="pronunciation-line">
+                <div class="card-content romaji"></div>
+                <button
+                  class="speak"
+                  data-target="romaji"
+                  title="Hear the romaji pronunciation"
+                >🔊</button>
+              </div>
+              <div class="pronunciation-line">
+                <div class="card-content japanese"></div>
+                <button
+                  class="speak"
+                  data-target="japanese"
+                  title="Hear this in Japanese"
+                >🔊</button>
+              </div>
+            </div>
             <div class="card-tags"></div>
-            <button class="speak" data-target="japanese" title="Hear this in Japanese">🔊</button>
           </div>
         </div>
         <button id="flipCard" class="secondary" disabled>Flip Card</button>
@@ -105,10 +119,6 @@
         <div class="field">
           <label for="voiceSelect">Japanese voice</label>
           <select id="voiceSelect"></select>
-        </div>
-        <div class="field">
-          <label for="englishVoiceSelect">English voice</label>
-          <select id="englishVoiceSelect"></select>
         </div>
         <p class="hint">If no voices appear, try clicking anywhere or refreshing after enabling text-to-speech in your browser.</p>
       </section>

--- a/style.css
+++ b/style.css
@@ -136,6 +136,29 @@ main {
   padding-top: 0.75rem;
 }
 
+.card-pronunciation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pronunciation-line {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.pronunciation-line .card-content {
+  flex: 1 1 auto;
+}
+
+.pronunciation-line .speak {
+  width: 2.5rem;
+  height: 2.5rem;
+  font-size: 1.1rem;
+}
+
 .card.show-back .card-face.back {
   display: flex;
 }


### PR DESCRIPTION
## Summary
- replace the front-side English speech control with dedicated romaji and Japanese playback buttons on the answer side
- remove the English voice selector and drive both pronunciations from the chosen Japanese voice
- disable playback when no text is present and ensure text-to-speech speaks exactly what is rendered on the card

## Testing
- Manual testing in browser


------
https://chatgpt.com/codex/tasks/task_e_68dd8b5863088325a0f84c44d220c468